### PR TITLE
fixes #3: allow migrate to be run a second time

### DIFF
--- a/versions/models.py
+++ b/versions/models.py
@@ -418,7 +418,7 @@ class VersionedManyToManyField(ManyToManyField):
         # - creating the through class if unset
         # - resolving the through class if it's a string
         # - resolving string references within the through class
-        if not self.rel.through and not cls._meta.abstract and not cls._meta.swapped:
+        if not self.rel.through and not cls._meta.abstract and not cls._meta.swapped and cls.__module__ != '__fake__':
             self.rel.through = VersionedManyToManyField.create_versioned_many_to_many_intermediary_model(self, cls,
                                                                                                          name)
         super(VersionedManyToManyField, self).contribute_to_class(cls, name)


### PR DESCRIPTION
This allows running " ./manage.py migrate && ./manage.py migrate"  or "./manage.py syncdb && ./manage.py syncdb" to succeed on django 1.7.

I can't honestly say I've understood everything that the django 1.7 migrations are doing yet, but at some point it creates the database models using a module name of **fake**.

I think this is a safe change, but am not sure what the implications are for real-life migration scenarios.
