### PR TITLE
Bugfix: None in M2M relationships

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ If you get errors, check the following things:
 """
 
 setup(name='CleanerVersion',
-      version='1.2.1',
+      version='1.2.2',
       description='A versioning solution for relational data models',
       long_description='CleanerVersion is a solution that allows you to read and write multiple versions of an entry '
                        'to and from your relational database. It allows to keep track of modifications on an object '

--- a/versions/models.py
+++ b/versions/models.py
@@ -674,7 +674,7 @@ class VersionedReverseManyRelatedObjectsDescriptor(ReverseManyRelatedObjectsDesc
     'related_manager_cls' property
     """
 
-    def __get__(self, instance, owner):
+    def __get__(self, instance, owner=None):
         """
         Reads the property as which this object is figuring; mainly used for debugging purposes
         :param instance: The instance on which the getter was called
@@ -704,7 +704,7 @@ class VersionedManyRelatedObjectsDescriptor(ManyRelatedObjectsDescriptor):
         super(VersionedManyRelatedObjectsDescriptor, self).__init__(related)
         self.via_field_name = via_field_name
 
-    def __get__(self, instance, owner):
+    def __get__(self, instance, owner=None):
         """
         Reads the property as which this object is figuring; mainly used for debugging purposes
         :param instance: The instance on which the getter was called

--- a/versions/tests.py
+++ b/versions/tests.py
@@ -1229,5 +1229,3 @@ class ManyToManyFilteringTest(TestCase):
             count = C3.objects.as_of(self.t2) \
                 .filter(c2s__c1s__name__startswith='c1').propagate_querytime().all().count()
             self.assertEqual(2, count)
-
-


### PR DESCRIPTION
Fixed a small bug occurring in some special cases, mainly due to incorrect overwriting of RelatedObjectsDescriptors by Django
