### PR TITLE
Use Django-internal six copy

### DIFF
--- a/versions/models.py
+++ b/versions/models.py
@@ -26,7 +26,7 @@ from django.db.models.query import QuerySet, ValuesListQuerySet, ValuesQuerySet
 from django.db.models.signals import post_init
 from django.utils.functional import cached_property
 from django.utils.timezone import utc
-import six
+from django.utils import six
 import uuid
 
 from django.db import models, router

--- a/versions/tests.py
+++ b/versions/tests.py
@@ -18,7 +18,7 @@ from django.db.models.fields import CharField
 from django.test import TestCase
 import datetime
 from django.utils.timezone import utc
-import six
+from django.utils import six
 from time import sleep
 import itertools
 


### PR DESCRIPTION
Use Django's internal copy of six; this is a possible fix for bug #15 . 
