### PR TITLE
Only use query_time when it has explicitly been set via as_of

### DIFF
--- a/versions/tests.py
+++ b/versions/tests.py
@@ -1020,14 +1020,9 @@ class SelfOneToManyTest(TestCase):
         Directory.objects.create(name='subdir3.v1', parent=current_parentdir)
         t2 = get_utc_now()
 
-        # there must not be 3 subdirectories in the parent directory, since current_parentdir holds the state
-        # at t1 - prior to adding "subdir3"
-        self.assertNotEqual(3, current_parentdir.directory_set.all().count())
-        # If we wanted this comparision to be equal, we'd need to removed the 'as_of' timestamp within 'current_parentdir'
-        # Let's do that:
-        current_parentdir.as_of = None
+        # There must be 3 subdirectories in the parent directory now. Since current_parentdir has never had an as_of
+        # specified, it will reflect the current state.
         self.assertEqual(3, current_parentdir.directory_set.all().count())
-
 
         # there should be 2 directories in the parent directory at time t1
         parentdir_at_t1 = Directory.objects.as_of(t1).filter(name='parent.v1').first()


### PR DESCRIPTION
I propose that we change how query_time is handled.

Up until now,  code like:

```
# Authors.books is a many-to-many relationship
Authors.objects.create(name="Joe")
a1 = Authors.objects.current(name="Joe")
book = Books.objects.create(name="The love life of beetles")
a1.books.add(book)
print a1.books.all().count()
```

would print out "0", because when a1 was fetched, it's query_time was set to the time the fetch query was made.  I think it should print out "1".

What I'm proposing, is that an object that is fetched via objects.current, or has had it's as_of time explicitly set to None, will reflect the ongoing current state, not the state at the time when the object was fetched.

I propose this for two reasons:
1) It makes more sense to me.
2) It helps another pull request I'll make work.  The other pull request deals with adding multiple objects at once to a many-to-many relationship (e.g. a1.books.add(book1, book2, book3)).
