### PR TITLE
Change query time propagation handling

### DIFF
--- a/versions/models.py
+++ b/versions/models.py
@@ -14,22 +14,22 @@
 
 import copy
 import datetime
+import uuid
 from django import VERSION
 from django.core.exceptions import SuspiciousOperation, MultipleObjectsReturned, ObjectDoesNotExist
 from django.db.models.base import Model
-from django.db.models.constants import LOOKUP_SEP
-
 from django.db.models import Q
 from django.db.models.fields import FieldDoesNotExist
-from django.db.models.fields.related import ForeignKey, ReverseSingleRelatedObjectDescriptor, \
-    ReverseManyRelatedObjectsDescriptor, ManyToManyField, ManyRelatedObjectsDescriptor, create_many_related_manager, \
-    ForeignRelatedObjectsDescriptor
+from django.db.models.fields.related import (ForeignKey, ReverseSingleRelatedObjectDescriptor,
+    ReverseManyRelatedObjectsDescriptor, ManyToManyField, ManyRelatedObjectsDescriptor, create_many_related_manager,
+    ForeignRelatedObjectsDescriptor, ManyToOneRel)
 from django.db.models.query import QuerySet, ValuesListQuerySet, ValuesQuerySet
 from django.db.models.signals import post_init
+from django.db.models.sql import Query
+from django.db.models.sql.where import ExtraWhere
 from django.utils.functional import cached_property
 from django.utils.timezone import utc
 from django.utils import six
-import uuid
 
 from django.db import models, router
 
@@ -113,7 +113,7 @@ class VersionManager(models.Manager):
 
     @property
     def current(self):
-        return self.filter(version_end_date__isnull=True)
+        return self.as_of(None)
 
     def create(self, **kwargs):
         """
@@ -141,6 +141,65 @@ class VersionManager(models.Manager):
         kwargs['version_birth_date'] = timestamp
         return super(VersionManager, self).create(**kwargs)
 
+class VersionedQuery(Query):
+    """
+    VersionedQuery has awareness of the query time restrictions.  When the query is compiled,
+    this query time information is passed along to the foreign keys involved in the query, so
+    that they can provide that information when building the sql.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(VersionedQuery, self).__init__(*args, **kwargs)
+        self.set_as_of(None, False)
+
+    def clone(self, *args, **kwargs):
+        obj = super(VersionedQuery, self).clone(*args, **kwargs)
+        try:
+            obj.set_as_of(self.as_of_time, self.apply_as_of_time)
+        except AttributeError:
+            # If the caller is using clone to create a different type of Query, that's OK.
+            # An example of this is when creating or updating an object, this method is called
+            # with a first parameter of sql.UpdateQuery.
+            pass
+        return obj
+
+    def set_as_of(self, as_of_time, apply_as_of_time):
+        """
+        Set the as_of time that will be used to restrict the query for the valid objects.
+        :param DateTime as_of_time: Datetime or None (None means use the current objects)
+        :param bool apply_as_of_time: If false, then the query will not be restricted by as_of_time
+        :return:
+        """
+        self.as_of_time = as_of_time
+        self.apply_as_of_time = apply_as_of_time
+
+    def get_compiler(self, *args, **kwargs):
+        # Wait! One more thing before returning the compiler:
+        # propagate the query time to all the related foreign key fields.
+        self.propagate_query_time()
+        return super(VersionedQuery, self).get_compiler(*args, **kwargs)
+
+    def propagate_query_time(self):
+        """
+        This sets as query time, or lack of query time, on all the foreign keys
+        involved in the query.  Only if they are aware of the query time can they
+        create a time-based restriction in the JOIN ON clause.  In the case of
+        left outer joins, it is necessary that the time-based restriction happens
+        in the JOIN ON clause.  For inner joins, it doesn't hurt.
+        """
+        first = True
+        for alias in self.tables:
+            if not self.alias_refcount[alias]:
+                continue
+            try:
+                name, alias, join_type, lhs, join_cols, _, join_field = self.alias_map[alias]
+            except KeyError:
+                # Extra tables can end up in self.tables, but not in the
+                # alias_map if they aren't in a join. That's OK. We skip them.
+                continue
+            if join_type and not first:
+                join_field.set_as_of(self.as_of_time, self.apply_as_of_time)
+            first = False
 
 class VersionedQuerySet(QuerySet):
     """
@@ -150,13 +209,14 @@ class VersionedQuerySet(QuerySet):
     for its parent class (QuerySet).
     """
 
-    query_time = None
-
-    def __init__(self, *args, **kwargs):
-        super(VersionedQuerySet, self).__init__(*args, **kwargs)
-
-        self.related_table_in_filter = set()
-        """We will store in it all the tables we have being using in while filtering."""
+    def __init__(self, model=None, query=None, *args, **kwargs):
+        """
+        Overridden so that a VersionedQuery will be used.
+        """
+        if not query:
+            query = VersionedQuery(model)
+        super(VersionedQuerySet, self).__init__(model=model, query=query, *args, **kwargs)
+        self.query_time = None
 
     def __getitem__(self, k):
         """
@@ -210,7 +270,6 @@ class VersionedQuerySet(QuerySet):
 
         clone = super(VersionedQuerySet, self)._clone(**kwargs)
         clone.query_time = self.query_time
-        clone.related_table_in_filter = self.related_table_in_filter
 
         return clone
 
@@ -241,6 +300,7 @@ class VersionedQuerySet(QuerySet):
         :param qtime: The UTC date and time; if None then use the current state (where version_end_date = NULL)
         :return: A VersionedQuerySet
         """
+        self.query.set_as_of(qtime, True)
         return self.add_as_of_filter(qtime)
 
     def add_as_of_filter(self, querytime):
@@ -261,147 +321,6 @@ class VersionedQuerySet(QuerySet):
             filter = Q(version_end_date__isnull=True)
         return self.filter(filter)
 
-    def propagate_querytime(self, relation_table=None):
-        """
-        Propagate the query_time information found on the VersionedQuerySet
-        object to the given table or on table on which we have filtered on.
-
-        When relation_table is given it will be used and a clause will be
-        added to the generated query so that the matching object found on the
-        given relation_table will be restricted to the query_time specified
-        on the QuerySet. This usage is only use in the VersionManyRelatedManager.
-
-        When relation_table is not given then the function will use the list
-        of table we have build while using the filter(). Every time we
-        use filter() to filter on the other side of a relation we gather the tables
-        on which we have filtered (see _filter_or_exclude()). This list is then
-        used by propagate_querytime() to add to the QuerySet where clauses
-        restricting the matching records to the one that were active at the
-        query_time specified on the QuerySet.
-
-        :param relation_table: name of table to apply the limit on.
-        """
-        if relation_table:
-            relation_tables = [relation_table]
-        else:
-            relation_tables = self.related_table_in_filter
-
-        query_time = self.query_time
-        where_clauses = []
-        params = []
-        for relation_table in relation_tables:
-            if query_time:
-                # There was a query_time set on the current VersionedQuerySet (self), so propagate it
-                where_clauses.append(
-                    '''{table}.version_start_date <= %s
-                        AND ({table}.version_end_date > %s OR {table}.version_end_date is NULL )
-                    '''.format(table=relation_table))
-                params += [query_time, query_time]
-            else:
-                # There was no query_time set on the current VersionedQuerySet (self), so look for "current" entries
-                where_clauses.append("{0}.version_end_date is NULL".format(relation_table))
-
-        return self.extra(where=where_clauses, params=params)
-
-    def _filter_or_exclude(self, negate, *args, **kwargs):
-        queryset = super(VersionedQuerySet, self)._filter_or_exclude(negate, *args, **kwargs)
-        model_class = self.model
-
-        def path_stack_to_tables(model_class, paths_stack, tables=None):
-            """
-            Recursive function that will navigate the tables found in 'paths_stack'
-            and build up a list of all the tables we have visited.
-
-            The found tables are gathered in the collector variable 'tables' which
-            is initially empty on the first call.
-
-            On each recursive call we pop from 'paths_stack' until there is no more
-            tables to navigate.
-
-            The 'paths_stack' is created by exploding a filter expression on the
-            lookup separator, dropping the last item of the expression and then
-            reversing the obtained list.
-
-            Example:
-                filter expression: student__professor__name__startswith
-                after exploding: ['student', 'professor', 'name']
-                paths_stack: ['name', 'professor', 'student']
-            """
-            if not tables:
-                tables = []
-
-            attribute = paths_stack.pop()
-            try:
-                field_object, model, direct, m2m = model_class._meta.get_field_by_name(attribute)
-
-                # This is the counter part of one-to-many field
-                if not direct:
-                    table_name = field_object.model._meta.db_table
-                    tables.append(table_name)
-
-                if m2m:
-                    if isinstance(field_object, VersionedManyToManyField):
-                        table_name = field_object.m2m_db_table()
-                    else:
-                        table_name = field_object.field.m2m_db_table()
-
-                    tables.append(table_name)
-
-                if isinstance(field_object, VersionedForeignKey):
-                    table_name = field_object.rel.to._meta.db_table
-                    tables.append(table_name)
-
-            except FieldDoesNotExist:
-                # Of course in some occasion the filed might not be found,
-                # that's accepted
-                pass
-
-            if not paths_stack:
-                return tables
-            else:
-                if isinstance(field_object, VersionedManyToManyField)\
-                        or isinstance(field_object, VersionedForeignKey):
-                    model_class = field_object.rel.to
-                else:
-                    model_class = field_object.model
-
-                return path_stack_to_tables(model_class, paths_stack, tables)
-
-        def flatten_Q(q, expressions):
-            """
-            Recursive function that flattens the tree of Q nodes into a list
-            of filtering expressions.
-
-            For each Q node we visit its children. If the children is a tuple
-            we have reach the bottom of the tree and we read the first element
-            of the tuple (which is the filtering expression). If the children
-            is a Q node we recursively walk down on it.
-            """
-            for c in q.children:
-                if isinstance(c, tuple):
-                    expressions.append(c[0])
-                else:
-                    e = flatten_Q(c, expressions)
-                    expressions.extend(e)
-                    return expressions
-
-            return expressions
-
-        filter_expression_list = []
-
-        for q in args:
-            filter_expression_list.extend(flatten_Q(q, []))
-
-        filter_expression_list.extend(list(kwargs))
-
-        for filter_expression in filter_expression_list:
-            paths_stack = list(reversed(filter_expression.split(LOOKUP_SEP)[:-1]))
-            if paths_stack:
-                tables = path_stack_to_tables(model_class, paths_stack)
-                queryset.related_table_in_filter = queryset.related_table_in_filter.union(tables)
-
-        return queryset
-
     def values_list(self, *fields, **kwargs):
         """
         Overridden so that an as_of filter will be added to the queryset returned by the parent method.
@@ -410,11 +329,45 @@ class VersionedQuerySet(QuerySet):
         return qs.add_as_of_filter(qs.query_time)
 
 
+class VersionedManyToOneRel(ManyToOneRel):
+    """
+    Overridden to allow keeping track of the query as_of time, so that foreign keys
+    can use that information when creating the sql joins.
+    """
+
+    def set_as_of(self, as_of_time, apply_as_of_time):
+        """
+        Set the as_of time that will be used to restrict the query for the valid objects.
+        :param DateTime as_of_time: Datetime or None (None means use the current objects)
+        :param bool apply_as_of_time: If false, then the query will not be restricted by as_of_time
+        :return:
+        """
+        self.as_of_time = as_of_time
+        self.apply_as_of_time = apply_as_of_time
+        if hasattr(self, 'field'):
+            self.field.set_as_of(as_of_time, apply_as_of_time)
+
+
 class VersionedForeignKey(ForeignKey):
     """
     We need to replace the standard ForeignKey declaration in order to be able to introduce
     the VersionedReverseSingleRelatedObjectDescriptor, which allows to go back in time...
+    We also default to using the VersionedManyToOneRel, which helps us correctly limit results
+    when joining tables via foreign and many-to-many relation fields.
     """
+    def __init__(self, to, rel_class=ManyToOneRel, **kwargs):
+        super(VersionedForeignKey, self).__init__(to, rel_class=VersionedManyToOneRel, **kwargs)
+        self.set_as_of(None, False)
+
+    def set_as_of(self, as_of_time, apply_as_of_time):
+        """
+        Set the as_of time that will be used to restrict the query for the valid objects.
+        :param DateTime as_of_time: Datetime or None (None means use the current objects)
+        :param bool apply_as_of_time: If false, then the query will not be restricted by as_of_time
+        :return:
+        """
+        self.as_of_time = as_of_time
+        self.apply_as_of_time = apply_as_of_time
 
     def contribute_to_class(self, cls, name, virtual_only=False):
         super(VersionedForeignKey, self).contribute_to_class(cls, name, virtual_only)
@@ -431,6 +384,18 @@ class VersionedForeignKey(ForeignKey):
         if hasattr(cls, accessor_name):
             setattr(cls, accessor_name, VersionedForeignRelatedObjectsDescriptor(related))
 
+    def get_extra_restriction(self, where_class, alias, remote_alias):
+        cond = None
+        if self.apply_as_of_time:
+            if self.as_of_time:
+                sql = '''{alias}.version_start_date <= %s
+                         AND ({alias}.version_end_date > %s OR {alias}.version_end_date is NULL )'''.format(alias=remote_alias)
+                params = [self.as_of_time, self.as_of_time]
+            else:
+                sql = '''{alias}.version_end_date is NULL'''.format(alias=remote_alias)
+                params = None
+            cond = ExtraWhere([sql], params)
+        return cond
 
 class VersionedManyToManyField(ManyToManyField):
     def __init__(self, *args, **kwargs):
@@ -612,10 +577,7 @@ def create_versioned_many_related_manager(superclass, rel):
             """
 
             queryset = super(VersionedManyRelatedManager, self).get_queryset()
-            if self.instance.as_of is not None:
-                queryset = queryset.as_of(self.instance.as_of)
-
-            return queryset.propagate_querytime(self.through._meta.db_table)
+            return queryset.as_of(self.instance.as_of)
 
         def _remove_items(self, source_field_name, target_field_name, *objs):
             """

--- a/versions/tests.py
+++ b/versions/tests.py
@@ -16,7 +16,7 @@ import datetime
 from time import sleep
 import itertools
 from django.core.exceptions import SuspiciousOperation, ObjectDoesNotExist, MultipleObjectsReturned, ValidationError
-from django.db.models import Q
+from django.db.models import Q, Count, Sum
 from django.db.models.fields import CharField
 from django.test import TestCase, TransactionTestCase
 from django.utils.timezone import utc
@@ -158,6 +158,7 @@ class MultiM2MTest(TestCase):
         self.assertEqual(mr_biggs_t0.name, 'Mr. Biggs')
         self.assertEqual(mr_biggs_t0.address, '123 Mainstreet, Somewhere')
         self.assertEqual(len(mr_biggs_t0.students.all()), 2)
+
         for student in mr_biggs_t0.students.all():
             self.assertIn(student.name, ['Annika', 'Benny'])
 
@@ -305,6 +306,27 @@ class MultiM2MTest(TestCase):
         self.assertSetEqual(set([o.pk for o in benny4.professors.all()]), set(some_professor_ids))
         self.assertSetEqual(set(list(benny5.professors.all())), set())
 
+    def test_annotations_and_aggregations(self):
+
+        # Annotations and aggreagations should work with .current objects as well as historical .as_of() objects.
+        self.assertEqual(4,
+            Professor.objects.current.annotate(num_students=Count('students')).aggregate(sum=Sum('num_students'))['sum']
+        )
+        self.assertTupleEqual((1,1),
+            (Professor.objects.current.annotate(num_students=Count('students')).get(name='Mr. Biggs').num_students,
+             Professor.objects.current.get(name='Mr. Biggs').students.count())
+        )
+
+        self.assertTupleEqual((2,2),
+            (Professor.objects.as_of(self.t1).annotate(num_students=Count('students')).get(name='Mr. Biggs').num_students,
+             Professor.objects.as_of(self.t1).get(name='Mr. Biggs').students.count())
+        )
+
+        # Results should include records for which the annotation returns a 0 count, too.
+        # This requires that the generated LEFT OUTER JOIN condition includes a clause
+        # to restrict the records according to the desired as_of time.
+        self.assertEqual(3, len(Student.objects.current.annotate(num_teachers=Count('professors')).all()))
+
 
 class Pupil(Versionable):
     name = CharField(max_length=200)
@@ -357,15 +379,15 @@ class MultiM2MToSameTest(TestCase):
 
     def test_filtering_on_the_other_side_of_relation(self):
         language_pupils_count = Pupil.objects.as_of(self.t0).filter(
-            language_teachers__name='Ms. Sue').propagate_querytime().count()
+            language_teachers__name='Ms. Sue').count()
         self.assertEqual(0, language_pupils_count)
 
         language_pupils_count = Pupil.objects.as_of(self.t1).filter(
-            language_teachers__name='Ms. Sue').propagate_querytime().count()
+            language_teachers__name='Ms. Sue').count()
         self.assertEqual(1, language_pupils_count)
 
         language_pupils_count = Pupil.objects.as_of(self.t2).filter(
-            language_teachers__name='Ms. Sue').propagate_querytime().count()
+            language_teachers__name='Ms. Sue').count()
         self.assertEqual(0, language_pupils_count)
 
     def test_t0(self):
@@ -972,20 +994,20 @@ class OneToManyTest(TestCase):
         self.assertEqual(1, Player.objects.as_of(t1).filter(name='p2.v1').all().count())
 
         # at t1 there should be one team with two players
-        p1 = Team.objects.as_of(t1).filter(player__name='p1.v1').propagate_querytime().first()
+        p1 = Team.objects.as_of(t1).filter(player__name='p1.v1').first()
         self.assertIsNotNone(p1)
-        p2 = Team.objects.as_of(t1).filter(player__name='p2.v1').propagate_querytime().first()
+        p2 = Team.objects.as_of(t1).filter(player__name='p2.v1').first()
         self.assertIsNotNone(p2)
 
         # at t2 there should be one team with one single player called 'p1.v1'
-        p1 = Team.objects.as_of(t2).filter(player__name='p1.v1').propagate_querytime().first()
-        p2 = Team.objects.as_of(t2).filter(player__name='p2.v1').propagate_querytime().first()
+        p1 = Team.objects.as_of(t2).filter(player__name='p1.v1').first()
+        p2 = Team.objects.as_of(t2).filter(player__name='p2.v1').first()
         self.assertIsNotNone(p1)
         self.assertIsNone(p2)
 
         # at t3 there should be one team with no players
-        p1 = Team.objects.as_of(t3).filter(player__name='p1.v1').propagate_querytime().first()
-        p2 = Team.objects.as_of(t3).filter(player__name='p2.v1').propagate_querytime().first()
+        p1 = Team.objects.as_of(t3).filter(player__name='p1.v1').first()
+        p2 = Team.objects.as_of(t3).filter(player__name='p2.v1').first()
         self.assertIsNone(p1)
         self.assertIsNone(p2)
 
@@ -1216,7 +1238,7 @@ class ManyToManyFilteringTest(TestCase):
         information across all tables
         """
         should_be_c1 = C1.objects.as_of(self.t1) \
-            .filter(c2s__name__startswith='c2').propagate_querytime().first()
+            .filter(c2s__name__startswith='c2').first()
         self.assertIsNotNone(should_be_c1)
 
     def test_filtering_one_jump_reverse(self):
@@ -1234,7 +1256,7 @@ class ManyToManyFilteringTest(TestCase):
         direction
         """
         should_be_c3 = C3.objects.as_of(self.t1) \
-            .filter(c2s__name__startswith='c2').propagate_querytime().first()
+            .filter(c2s__name__startswith='c2').first()
         self.assertIsNotNone(should_be_c3)
         self.assertEqual(should_be_c3.name, 'c3.v1')
 
@@ -1253,12 +1275,12 @@ class ManyToManyFilteringTest(TestCase):
         """
         with self.assertNumQueries(2) as counter:
             should_be_c1 = C1.objects.as_of(self.t1) \
-                .filter(c2s__c3s__name__startswith='c3').propagate_querytime().first()
+                .filter(c2s__c3s__name__startswith='c3').first()
             self.assertIsNotNone(should_be_c1)
             self.assertEqual(should_be_c1.name, 'c1.v1')
 
             count = C1.objects.as_of(self.t1) \
-                .filter(c2s__c3s__name__startswith='c3').propagate_querytime().all().count()
+                .filter(c2s__c3s__name__startswith='c3').all().count()
             self.assertEqual(1, count)
 
     def test_filtering_two_jumps_with_version_at_t2(self):
@@ -1268,11 +1290,11 @@ class ManyToManyFilteringTest(TestCase):
         """
         with self.assertNumQueries(2) as counter:
             should_be_c1 = C1.objects.as_of(self.t2) \
-                .filter(c2s__c3s__name__startswith='c3a').propagate_querytime().first()
+                .filter(c2s__c3s__name__startswith='c3a').first()
             self.assertIsNotNone(should_be_c1)
 
             count = C1.objects.as_of(self.t2) \
-                .filter(c2s__c3s__name__startswith='c3').propagate_querytime().all().count()
+                .filter(c2s__c3s__name__startswith='c3').all().count()
             self.assertEqual(2, count)
 
     def test_filtering_two_jumps_reverse(self):
@@ -1292,12 +1314,12 @@ class ManyToManyFilteringTest(TestCase):
         """
         with self.assertNumQueries(2) as counter:
             should_be_c3 = C3.objects.as_of(self.t1). \
-                filter(c2s__c1s__name__startswith='c1').propagate_querytime().first()
+                filter(c2s__c1s__name__startswith='c1').first()
             self.assertIsNotNone(should_be_c3)
             self.assertEqual(should_be_c3.name, 'c3.v1')
 
             count = C3.objects.as_of(self.t1) \
-                .filter(c2s__c1s__name__startswith='c1').propagate_querytime().all().count()
+                .filter(c2s__c1s__name__startswith='c1').all().count()
             self.assertEqual(1, count)
 
     def test_filtering_two_jumps_reverse_with_version_at_t2(self):
@@ -1308,9 +1330,9 @@ class ManyToManyFilteringTest(TestCase):
         """
         with self.assertNumQueries(2) as counter:
             should_be_c3 = C3.objects.as_of(self.t2) \
-                .filter(c2s__c1s__name__startswith='c1').propagate_querytime().first()
+                .filter(c2s__c1s__name__startswith='c1').first()
             self.assertIsNotNone(should_be_c3)
 
             count = C3.objects.as_of(self.t2) \
-                .filter(c2s__c1s__name__startswith='c1').propagate_querytime().all().count()
+                .filter(c2s__c1s__name__startswith='c1').all().count()
             self.assertEqual(2, count)


### PR DESCRIPTION
Previously, we were handling query time propagation by adding
where clauses.  However, this didn't work properly for certain
cases, like when using annotations.  Annotations create LEFT
OUTER JOIN clauses, and in some cases the only way to get the
correct results is to have the query time restriction specified
in the JOIN ON clause instead of the WHERE clause.

The code in this commit makes all the query time restriction happen
in the JOIN ON clauses.

It also eliminates the need to manually call propagate_querytime()
when traversing many-to-many relationships.
