### PR TITLE
Added an initial tox config for easier local testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,9 @@ dist/*
 build/*
 *.egg-info
 
+# Ignore testing output
+.coverage
+.tox
+
 # dev_no_debug.py imports local.py and disables Django-debugging
 cleanerversion/settings/dev_no_debug.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,20 @@
 language: python
-python:
-  - "2.7"
-  - "3.4"
+python: "2.7"
+
 env:
-  - DJANGO_VERSION=1.6.7
-  - DJANGO_VERSION=1.6.8
-  - DJANGO_VERSION=1.7
-  - DJANGO_VERSION=1.7.1
+  - TOX_ENV=py27-django16
+  - TOX_ENV=py27-django17
+  - TOX_ENV=py34-django16
+  - TOX_ENV=py34-django17
 
 # Dependencies
 install:
-  - pip install -q django==$DJANGO_VERSION
+  - pip install tox
   - pip install coveralls
 
 # Run tests
 script:
-  coverage run --source=versions ./manage.py test
+  tox -e $TOX_ENV
 
 # Run coveralls
 after_success:

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = 
+	py{27,34}-django{16,17}
+
+[testenv]
+deps =
+	coverage
+	django16: django>=1.6,<1.7
+	django17: django>=1.7,<1.8
+commands = 
+	coverage run --source=versions ./manage.py test


### PR DESCRIPTION
This PR makes use of tox for testing. 
With this PR, users on Linux can test CleanerVersion by running 'tox' in the project's root directory. 
Users on Windows (working with a vagrant/VirtualBox setup) will still not be able to use tox, since there seems to be a bug in the FS implementation used by VirtualBox, which does not allow to create hard links, which in turn prevents 'python setup.py install' to terminate properly.
