### PR TITLE
Add prefetch_related support

### DIFF
--- a/versions_tests/models.py
+++ b/versions_tests/models.py
@@ -46,6 +46,10 @@ class Player(Versionable):
 
     __str__ = versionable_description
 
+class Award(Versionable):
+    name = CharField(max_length=200)
+    players = VersionedManyToManyField(Player, related_name='awards')
+
 
 ############################################
 # SelfOneToManyTest models


### PR DESCRIPTION
Django caches prefetched foreign key and m2m objects in
the queryset object.  Previously, when accessing the
attributes that were cached, as_of() was adding a filter
to the current queryset, which resulted in the prefetched
objects cache being lost.

With this commit, as_of() just updates the queryset's
(and the query's) querytime attribute.  The query adds a clause
to restrict the querytime at the last moment, just before sql is
generated.  as_of() still returns a cloned queryset, so
that when one does:
    qs = Foo.objects.as_of(t1)
    first_foo = qs.as_of(t2).first()
the querytime for qs is still set to t1, so qs can be
re-used for other queries as expected.

The handling of querytime was adapted; now the queryset,
the query, and Versionable objects all use the same representation
for the querytime.  With this QueryTime object, it is possible to
know if a time restriction should be applied, and if so, whether
it should restrict to current objects or to a specific point
in time.

The behaviour of qs.as_of(t1).as_of(t2) has changed.
Previously it would add both clauses, which doesn't really
make sense.  Now it uses the last supplied value (here: t2).

The public API for Versionable remains unchanged.
