### PR TITLE
Take m2m through table tablespace from defining models Meta definition

### DIFF
--- a/versions/models.py
+++ b/versions/models.py
@@ -548,6 +548,7 @@ class VersionedManyToManyField(ManyToManyField):
         meta = type('Meta', (object,), {
             # 'unique_together': (from_, to),
             'auto_created': cls,
+            'db_tablespace': cls._meta.db_tablespace,
             'app_label': cls._meta.app_label,
         })
         return type(str(name), (Versionable,), {


### PR DESCRIPTION
This restore's Django's standard behaviour of creating a m2m through table in the same tablespace that the Model that declares the many-to-many field uses.