### PR TITLE
VersionedManyToManyField fields between different apps

### DIFF
--- a/versions/models.py
+++ b/versions/models.py
@@ -530,9 +530,11 @@ class VersionedManyToManyField(ManyToManyField):
 
         # Force 'to' to be a string (and leave the hard work to Django)
         if not isinstance(field.rel.to, six.string_types):
-            to = field.rel.to._meta.object_name
+            to = '%s.%s' % (field.rel.to._meta.app_label, field.rel.to._meta.object_name)
+            to_field_name = field.rel.to._meta.object_name.lower()
+        else:
+            to_field_name = to.lower()
         name = '%s_%s' % (from_, field_name)
-        to_field_name = to.lower()
 
         # Since Django 1.7, a migration mechanism is shipped by default with Django. This migration module loads all
         # declared apps' models inside a __fake__ module.


### PR DESCRIPTION
When creating a VersionedManyToManyField between two versioned models of different Django apps, you might run into an error like

```
$ python manage.py check
CommandError: System check identified some issues:

ERRORS:
appa.modela_modelb: (fields.E336) The model is used as an intermediate model by 'appa.modela.modelb', but it does not have a foreign key to 'ModelA' or 'ModelB'.
```
In my special case, this is a ManyToMany relation from a model `ModelA` of app `appa` to a model `ModelB` of `appb`, but with the complication that the ManyToMany relation is specified not in `ModelA`, but in `ModelA`'s abstract base class, which lives in `appb`.

The error occurs because your conversion of the `to` property to a string is ignorant of the app label. This pull request does fix this issue for me.