### PR TITLE
VersionedForeignKey from a non-versioned model

### DIFF
--- a/versions/models.py
+++ b/versions/models.py
@@ -59,7 +59,7 @@ class VersionManager(models.Manager):
         :return: VersionedQuerySet
         """
         qs = VersionedQuerySet(self.model, using=self._db)
-        if hasattr(self, 'instance'):
+        if hasattr(self, 'instance') and hasattr(self.instance, '_querytime'):
             qs.querytime = self.instance._querytime
         return qs
 
@@ -591,12 +591,15 @@ class VersionedReverseSingleRelatedObjectDescriptor(ReverseSingleRelatedObjectDe
         if not isinstance(current_elt, Versionable):
             raise TypeError("It seems like " + str(type(self)) + " is not a Versionable")
 
-        # If current_elt matches the instance's querytime, there's no need to make a database query.
-        if Versionable.matches_querytime(current_elt, instance._querytime):
-            current_elt._querytime = instance._querytime
-            return current_elt
+        if hasattr(instance, '_querytime'):
+            # If current_elt matches the instance's querytime, there's no need to make a database query.
+            if Versionable.matches_querytime(current_elt, instance._querytime):
+                current_elt._querytime = instance._querytime
+                return current_elt
 
-        return current_elt.__class__.objects.as_of(instance._querytime.time).get(identity=current_elt.identity)
+            return current_elt.__class__.objects.as_of(instance._querytime.time).get(identity=current_elt.identity)
+        else:
+            return current_elt.__class__.objects.current.get(identity=current_elt.identity)
 
 
 class VersionedForeignRelatedObjectsDescriptor(ForeignRelatedObjectsDescriptor):
@@ -687,8 +690,9 @@ def create_versioned_many_related_manager(superclass, rel):
             """
 
             queryset = super(VersionedManyRelatedManager, self).get_queryset()
-            if self.instance._querytime.active and self.instance._querytime != queryset.querytime:
-                queryset = queryset.as_of(self.instance._querytime.time)
+            if hasattr(queryset, 'querytime'):
+                if self.instance._querytime.active and self.instance._querytime != queryset.querytime:
+                    queryset = queryset.as_of(self.instance._querytime.time)
             return queryset
 
         def _remove_items(self, source_field_name, target_field_name, *objs):


### PR DESCRIPTION
In my application, I only need versioning for some parts of the application data. There are, however, relations between the versioned and the unversioned data. *cleanerversion* does not seem to have fundamental problems with this case, if you make the assumption that such keys should always point to the most recent version. However, builing such a relation has lead to three exceptions so far which are fixed by this pull request.

Everything seems to work fine but is not yet tested in a production-like environment, so there might me one or two more cases to consider.