### PR TITLE
Performance improvements

### DIFF
--- a/versions/models.py
+++ b/versions/models.py
@@ -1072,7 +1072,8 @@ class Versionable(models.Model):
         source = getattr(self, manager_field_name)  # returns a VersionedRelatedManager instance
         # Destination: the clone, where the cloned relations should point to
         destination = getattr(clone, manager_field_name)
-        destination.add(*list(source.all()))
+        for item in source.all():
+            destination.add(item)
 
         # retrieve all current m2m relations pointing the newly created clone
         # filter for source_id


### PR DESCRIPTION
As you might have noticed, cleanerversion creates a *huge* number of SQL queries when calling ``clone()`` on an item with many-to-many relationships. I'm working on improving this, and the three improvements in this pull request reduced the query load in my test environment by a factor of three or four. Here's what I did:

* Added an ``in_bulk`` parameter to ``clone()`` which is set to true when called from ``clone_relations``. The effect is that ``earlier_version.save()`` will not be called, but ``clone_relations`` will call ``bulk_create`` for them, as this issues only one SQL query instead of n. Also, the ``later_version`` objects, which are not modified by ``clone`` (when called on an unmodified object from the database, which is the case here), except for their ``version_start_date``, are now changed in a single ``.update()`` call.
* Removed a duplicate ``later_version.save()`` from ``clone()`` as I was unable to find *any* technical reason for it to be there.