### PR TITLE
Test correct behaviour while cloning M2M-related objects

### DIFF
--- a/versions_tests/tests/test_models.py
+++ b/versions_tests/tests/test_models.py
@@ -1097,8 +1097,8 @@ class MultiM2MTest(TestCase):
 
         # There are 12 queries against the DB:
         # - 3 for writing the new version of the object itself
-        # o 1 attempt to update the earlier version
-        # o 1 insert of the earlier version
+        #   o 1 attempt to update the earlier version
+        #   o 1 insert of the earlier version
         #   o 1 update of the later version
         # - 5 for the professors relationship
         #   o 1 for selecting all concerned professor objects


### PR DESCRIPTION
Ensuring correctness of M2M-relationships when cloning related objects.
Since there's a precise setup being done in the tests, we can predict the number of links present after doing an additional clone on one of the related objects.