### PR TITLE
Filter on fk rels

### DIFF
--- a/versions/models.py
+++ b/versions/models.py
@@ -491,18 +491,16 @@ class VersionedForeignKey(ForeignKey):
         for lhs_field, rhs_field in source:
             lhs_col_name = lhs_field.column
             rhs_col_name = rhs_field.column
-            if self is lhs_field:
-                # self is the current ForeignKey relationship
+            # Test whether
+            # - self is the current ForeignKey relationship
+            # - self was not auto_created (e.g. is not part of a M2M relationship)
+            if self is lhs_field and not self.auto_created:
                 if rhs_col_name == Versionable.VERSION_IDENTIFIER_FIELD:
                     rhs_col_name = Versionable.OBJECT_IDENTIFIER_FIELD
-            elif self is rhs_field:
+            elif self is rhs_field and not self.auto_created:
                 if lhs_col_name == Versionable.VERSION_IDENTIFIER_FIELD:
                     lhs_col_name = Versionable.OBJECT_IDENTIFIER_FIELD
             joining_columns = joining_columns + ((lhs_col_name, rhs_col_name),)
-        # joining_columns = super(VersionedForeignKey, self).get_joining_columns(reverse_join)
-        # TODO:
-        # if remote col is id and remote col is primary key and remote model is versioned:
-        # then replace id by identity
         return joining_columns
 
 
@@ -584,8 +582,8 @@ class VersionedManyToManyField(ManyToManyField):
         return type(str(name), (Versionable,), {
             'Meta': meta,
             '__module__': cls.__module__,
-            from_: VersionedForeignKey(cls, related_name='%s+' % name),
-            to_field_name: VersionedForeignKey(to, related_name='%s+' % name),
+            from_: VersionedForeignKey(cls, related_name='%s+' % name, auto_created=name),
+            to_field_name: VersionedForeignKey(to, related_name='%s+' % name, auto_created=name),
         })
 
 

--- a/versions_tests/tests/test_models.py
+++ b/versions_tests/tests/test_models.py
@@ -793,7 +793,7 @@ class OneToManyFilteringTest(TestCase):
             FROM "{team_table}"
             INNER JOIN
                 "{player_table}" ON (
-                    "{team_table}"."id" = "{player_table}"."team_id"
+                    "{team_table}"."identity" = "{player_table}"."team_id"
                     AND ((
                         {player_table}.version_start_date <= {ts}
                         AND (
@@ -1588,7 +1588,7 @@ class PrefetchingTests(TestCase):
                    "{team_table}"."name",
                    "{team_table}"."city_id"
             FROM "{player_table}"
-            LEFT OUTER JOIN "{team_table}" ON ("{player_table}"."team_id" = "{team_table}"."id"
+            LEFT OUTER JOIN "{team_table}" ON ("{player_table}"."team_id" = "{team_table}"."identity"
                                                       AND (({team_table}.version_start_date <= {ts}
                                                             AND ({team_table}.version_end_date > {ts}
                                                                  OR {team_table}.version_end_date IS NULL))))
@@ -1733,8 +1733,8 @@ class PrefetchingTests(TestCase):
                 self.assertTrue(new == old - 1)
 
 
-class FilterOnRelationTest(TestCase):
-    def test_filter_on_relation(self):
+class FilterOnForeignKeyRelationTest(TestCase):
+    def test_filter_on_fk_relation(self):
         team = Team.objects.create(name='team')
         player = Player.objects.create(name='player', team=team)
         t1 = get_utc_now()

--- a/versions_tests/tests/test_models.py
+++ b/versions_tests/tests/test_models.py
@@ -1696,3 +1696,15 @@ class PrefetchingTests(TestCase):
                 old = len(award_players[i].awards.all())
                 new = len(updated_award_players[i].awards.all())
                 self.assertTrue(new == old - 1)
+
+
+class FilterOnRelationTest(TestCase):
+    def test_filter_on_relation(self):
+        team = Team.objects.create(name='team')
+        player = Player.objects.create(name='player', team=team)
+        t1 = get_utc_now()
+        sleep(0.1)
+        l1 = len(Player.objects.as_of(t1).filter(team__name='team'))
+        team.clone()
+        l2 = len(Player.objects.as_of(t1).filter(team__name='team'))
+        self.assertEqual(l1, l2)


### PR DESCRIPTION
Added TestCase specified in issue #45 and bugfixed the code.
Now, ForeignKey relations get joined on the `identity` property of objects, such that time-constraint keep their effect of selecting a version of an object.

Also fixed a bug which had as an effect that time-constraints got added multiple time to a queryset (in fact, everytime `get_compiler()` on a `VersionedQuerySet` got called. Even if doing this doesn't invalidate the produced SQL, it gets hardly readable over time.

Finally, improved some comments on unit tests, in order to be able to recognize the absolute state of the system at any point in time t0-tn.