### PR TITLE
Slightly changed the TravisCI config file in order to follow the Travis-syntax for addons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 
 # Enable PostgreSQL usage
 addons:
-  - postgresql: "9.3"
+  postgresql: "9.3"
 
 # Dependencies
 install:


### PR DESCRIPTION
Looking at the TravisCI output, the effect of this modification is, that the ``addons``-part is taken into account, which was not the case previously.
This means, that we're not sure to always have tested against Postgres 9.3 on TravisCI (we did though on our Dev-machines).