### PR TITLE
Improve error message for unversioned VFK targets. See #54

### DIFF
--- a/versions/models.py
+++ b/versions/models.py
@@ -616,7 +616,9 @@ class VersionedReverseSingleRelatedObjectDescriptor(ReverseSingleRelatedObjectDe
             return None
 
         if not isinstance(current_elt, Versionable):
-            raise TypeError("VersionedForeignKey target is of type " + str(type(current_elt)) + ", which is not a subclass of Versionable")
+            raise TypeError("VersionedForeignKey target is of type "
+                + str(type(current_elt))
+                + ", which is not a subclass of Versionable")
 
         if hasattr(instance, '_querytime'):
             # If current_elt matches the instance's querytime, there's no need to make a database query.

--- a/versions/models.py
+++ b/versions/models.py
@@ -616,7 +616,7 @@ class VersionedReverseSingleRelatedObjectDescriptor(ReverseSingleRelatedObjectDe
             return None
 
         if not isinstance(current_elt, Versionable):
-            raise TypeError("It seems like " + str(type(self)) + " is not a Versionable")
+            raise TypeError("VersionedForeignKey target is of type " + str(type(current_elt)) + ", which is not a subclass of Versionable")
 
         if hasattr(instance, '_querytime'):
             # If current_elt matches the instance's querytime, there's no need to make a database query.


### PR DESCRIPTION
Just hit this thing again. Here's what the message looks like with this patch:

```
TypeError: VersionedForeignKey target is of type <class 'Color'>, which is not a subclass of Versionable
```

Here's what it used to be:

```
TypeError: It seems like <class 'versions.models.VersionedReverseSingleRelatedObjectDescriptor'> is not a Versionable
```