### PR TITLE
Restorable versions

### DIFF
--- a/docs/doc/historization_with_cleanerversion.rst
+++ b/docs/doc/historization_with_cleanerversion.rst
@@ -558,8 +558,13 @@ If there are multiple sets of columns that should be unique, use something like 
 
     VERSION_UNIQUE = [['field1', 'field2'], ['field3', 'field4']]
 
-For an example of how to transparently create the database indexes for these VERSION_UNIQUE definitions in a Django app, as well
-as removing the extra like indexes created on the CharField columns, see:
+As an extra method of protection against bad data appearing, it is good to ensure that only one version of an object
+is current at the same time.  This can be done by adding a partially unique index for the ``identity`` column.
+You can use ``versions.util.postgresql.create_current_version_unique_identity_indexes()`` for this.
+
+For an example of how to transparently create the database indexes for these VERSION_UNIQUE definitions in a Django
+app, removing the extra like indexes created on the CharField columns, and enforcing that only one version is current
+at the same time, see:
 
 * https://github.com/swisscom/cleanerversion/blob/master/versions_tests/__init__.py
 * https://github.com/swisscom/cleanerversion/blob/master/versions_tests/apps.py

--- a/docs/doc/historization_with_cleanerversion.rst
+++ b/docs/doc/historization_with_cleanerversion.rst
@@ -522,6 +522,19 @@ enforces that name and phone_number are unique together when the version_end_dat
 a similar capability.  A helper method for creating these partially unique indexes is provided for Postgresql, see
 the `Postgresql specific`_ section for more detail.
 
+Specifying the id of an object at creation time
+===============================================
+It is possible to specify an id when creating a new object, instead of letting CleanerVersion do this for you.  The
+id must be a unicode string representing a
+`version 4 UUID <http://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29>`_.
+
+**Be careful if you do this!**.  The possibility of collisions can increase greatly if not all sources that specify
+a UUID use sufficient entropy. See
+`this <http://en.wikipedia.org/wiki/Universally_unique_identifier#Random_UUID_probability_of_duplicates>`_ for more
+details.
+
+The database-level unique constraint on the id will prohibit a duplicate uuid from being inserted, but your application
+will need to be ready to handle that.
 
 Postgresql specific
 ===================

--- a/docs/doc/historization_with_cleanerversion.rst
+++ b/docs/doc/historization_with_cleanerversion.rst
@@ -535,6 +535,42 @@ PROTECTED
 ~~~~~~~~~
 Behaves just like in standard Django.
 
+Restoring previous versions
+===========================
+Previous versions can be restored like this::
+
+    restored_version = old_version.restore()
+
+``restored_version`` will now be the current version. This creates a new version, the old version is left untouched.
+If any current version existed when this code ran, it was terminated before the restored version was created.
+
+Be aware that relations (VersionedForeignKey, ManyToManyField, reverse foreign keys, etc.) are not restored.  You will
+need to restore relations yourself if necessary.
+
+If the object being restored has a non-nullable VersionedForeignKey, you will need to supply a value (object instance
+or pk) for this field.  If you do not supply a value, a ``versions.ForeignKeyRequiresValueError`` will be raised.
+
+Values can also be provided for other, non-ForeignKey fields at restore time.
+
+Example:
+
+Models::
+
+    class Team(Versionable):
+        name = models.CharField(max_length=50)
+
+    class Mascot(Versionable):
+        name = models.CharField(max_length=50)
+        age = models.IntegerField()
+        team = VersionedForeignKey(Team, null=False)
+
+Code::
+
+    beaver = beaver_v1.restore(team=mascot_v1.team)
+
+    new_team_pk = Team.objects.current.get(name='Black Stripes').pk
+    tiger = tiger_v4.restore(team=new_team_pk, age=33)
+
 Unique Indexes
 ==============
 To have unique indexes with versioned models takes a bit of care. The issue here is that multiple versions having the same

--- a/versions/deletion.py
+++ b/versions/deletion.py
@@ -1,0 +1,108 @@
+from django.db.models.deletion import (
+    attrgetter, signals, six, sql, transaction,
+    CASCADE,
+    Collector,
+)
+import versions.models
+
+
+class VersionedCollector(Collector):
+
+    def can_fast_delete(self, objs, from_field=None):
+        """Do not fast delete anything"""
+        return False
+
+    def is_versionable(self, model):
+        return hasattr(model, 'VERSION_IDENTIFIER_FIELD') and hasattr(model, 'OBJECT_IDENTIFIER_FIELD')
+
+    def delete(self, timestamp):
+        # sort instance collections
+        for model, instances in self.data.items():
+            self.data[model] = sorted(instances, key=attrgetter("pk"))
+
+        # if possible, bring the models in an order suitable for databases that
+        # don't support transactions or cannot defer constraint checks until the
+        # end of a transaction.
+        self.sort()
+
+        with transaction.commit_on_success_unless_managed(using=self.using):
+            # send pre_delete signals, but not for versionables
+            for model, obj in self.instances_with_model():
+                if not (self.is_versionable(model) or model._meta.auto_created):
+                    signals.pre_delete.send(
+                        sender=model, instance=obj, using=self.using
+                    )
+
+            # do not do fast deletes
+            if self.fast_deletes:
+                raise RuntimeError("No fast_deletes should be present; they are not safe for Versionables")
+
+            # update fields
+            for model, instances_for_fieldvalues in six.iteritems(self.field_updates):
+                id_map = {}
+                for (field, value), instances in six.iteritems(instances_for_fieldvalues):
+                    if self.is_versionable(model):
+                        # Do not set the foreign key to null, which can be the behaviour (depending on DB backend)
+                        # for the default CASCADE on_delete method.
+                        # In the case of a SET.. method, clone before changing the value (if it hasn't already been
+                        # cloned)
+                        updated_instances = set()
+                        if not(isinstance(field, versions.models.VersionedForeignKey) and field.rel.on_delete == CASCADE):
+                            for instance in instances:
+                                # Clone before updating
+                                cloned = id_map.get(instance.pk, None)
+                                if not cloned:
+                                    cloned = instance.clone()
+                                id_map[instance.pk] = cloned
+                                updated_instances.add(cloned)
+                                #TODO: instance should get updated with new values from clone ?
+                        instances_for_fieldvalues[(field, value)] = updated_instances
+
+                # Replace the instances with their clones in self.data, too
+                model_instances = self.data.get(model, {})
+                for index, instance in enumerate(model_instances):
+                    cloned = id_map.get(instance.pk)
+                    if cloned:
+                        self.data[model][index] = cloned
+
+                query = sql.UpdateQuery(model)
+                for (field, value), instances in six.iteritems(instances_for_fieldvalues):
+                    if instances:
+                        query.update_batch([obj.pk for obj in instances], {field.name: value}, self.using)
+
+            # reverse instance collections
+            for instances in six.itervalues(self.data):
+                instances.reverse()
+
+            # delete instances
+            for model, instances in six.iteritems(self.data):
+                if self.is_versionable(model):
+                    for instance in instances:
+                        instance._delete_at(timestamp, using=self.using)
+                    # do not send post_delete signals
+                else:
+                    query = sql.DeleteQuery(model)
+                    pk_list = [obj.pk for obj in instances]
+                    query.delete_batch(pk_list, self.using)
+
+                    if not model._meta.auto_created:
+                        for obj in instances:
+                            signals.post_delete.send(
+                                sender=model, instance=obj, using=self.using
+                            )
+
+        # update collected instances
+        for model, instances_for_fieldvalues in six.iteritems(self.field_updates):
+            for (field, value), instances in six.iteritems(instances_for_fieldvalues):
+                for obj in instances:
+                    setattr(obj, field.attname, value)
+
+        # Do not set Versionable object ids to None, since they still do have an id.
+        # Instead, set their version_end_date.
+        for model, instances in six.iteritems(self.data):
+            is_versionable = self.is_versionable(model)
+            for instance in instances:
+                if is_versionable:
+                    setattr(instance, 'version_end_date', timestamp)
+                else:
+                    setattr(instance, model._meta.pk.attname, None)

--- a/versions/models.py
+++ b/versions/models.py
@@ -1242,7 +1242,7 @@ class Versionable(models.Model):
                     try:
                         setattr(restored, field.name, None)
                     except ValueError as e:
-                        raise ForeignKeyRequiresValueError(e.message)
+                        raise ForeignKeyRequiresValueError(e.args[0])
 
         self.id = six.u(str(uuid.uuid4()))
 

--- a/versions/models.py
+++ b/versions/models.py
@@ -93,17 +93,15 @@ class VersionManager(models.Manager):
         if object.version_end_date == None:
             return object
         else:
-            try:
-                next = self.get(
-                    Q(identity=object.identity),
-                    Q(version_start_date=object.version_end_date))
-            except MultipleObjectsReturned as e:
-                raise MultipleObjectsReturned(
-                    "next_version couldn't uniquely identify the next version of object " + str(
-                        object.identity) + " to be returned\n" + str(e))
-            except ObjectDoesNotExist as e:
+            next = self.filter(
+                Q(identity=object.identity),
+                Q(version_start_date__gte=object.version_end_date)
+            ).order_by('version_start_date').first()
+
+            if not next:
                 raise ObjectDoesNotExist(
-                    "next_version couldn't find a next version of object " + str(object.identity) + "\n" + str(e))
+                    "next_version couldn't find a next version of object " + str(object.identity))
+
             return next
 
     def previous_version(self, object):
@@ -119,20 +117,15 @@ class VersionManager(models.Manager):
         if object.version_birth_date == object.version_start_date:
             return object
         else:
-            try:
-                previous = self.get(
-                    Q(identity=object.identity),
-                    Q(version_end_date=object.version_start_date))
-            except MultipleObjectsReturned as e:
-                raise MultipleObjectsReturned(
-                    "previous_version couldn't uniquely identify the previous version of object " + str(
-                        object.identity) + " to be returned\n" + str(e))
-            # This should never-ever happen, since going prior a first version of an object should be avoided by the
-            # first test of this method
-            except ObjectDoesNotExist as e:
+            previous = self.filter(
+                Q(identity=object.identity),
+                Q(version_end_date__lte=object.version_start_date)
+            ).order_by('-version_end_date').first()
+
+            if not previous:
                 raise ObjectDoesNotExist(
-                    "previous_version couldn't find a previous version of object " + str(object.identity) + "\n" + str(
-                        e))
+                    "previous_version couldn't find a previous version of object " + str(object.identity))
+
             return previous
 
     def current_version(self, object):
@@ -1044,22 +1037,35 @@ class Versionable(models.Model):
         return self.version_end_date is None
 
     @property
+    def is_latest(self):
+        """
+        Checks if this is the latest version.
+
+        Note that this will not check the database for a possible newer version.
+        It simply inspects the object's in-memory state.
+
+        :return: boolean
+        """
+        return self.id == self.identity
+
+    @property
+    def is_terminated(self):
+        """
+        Checks if this version has been terminated.
+
+        This will be true if a newer version has been created, or if the version has been "deleted".
+
+        :return: boolean
+        """
+        return self.version_end_date is not None
+
+    @property
     def as_of(self):
         return self._querytime.time
 
     @as_of.setter
     def as_of(self, time):
         self._querytime = QueryTime(time=time, active=True)
-
-    def _clone_at(self, timestamp):
-        """
-        WARNING: This method is only for internal use, it should not be used
-        from outside.
-
-        This function is mostly intended for testing, to allow creating
-        realistic test cases.
-        """
-        return self.clone(forced_version_date=timestamp)
 
     def clone(self, forced_version_date=None, in_bulk=False):
         """
@@ -1072,29 +1078,73 @@ class Versionable(models.Model):
         usually set only internally for performance optimization
         :return: returns a fresh clone of the original object (with adjusted relations)
         """
+        return self._clone(
+            old_version_end_date=forced_version_date, new_version_start_date=forced_version_date, in_bulk=in_bulk)
+
+    def _clone_at(self, timestamp):
+        """
+        WARNING: This method is only for internal use, it should not be used
+        from outside.
+
+        This function is mostly intended for testing, to allow creating
+        realistic test cases.
+        """
+        return self._clone(old_version_end_date=timestamp, new_version_start_date=timestamp)
+
+    def _clone(self, old_version_end_date=None, new_version_start_date=None, in_bulk=False, allow_restore=False):
+        """
+        Clones a Versionable and returns a fresh copy of the original object.
+        Original source: ClonableMixin snippet (http://djangosnippets.org/snippets/1271), with the pk/id change
+        suggested in the comments
+
+        :param forced_version_date: a timestamp including tzinfo; this value is usually set only internally!
+        :param in_bulk: whether not to write this objects to the database already, if not necessary; this value is
+        usually set only internally for performance optimization
+        :param allow_restore: if True, will allow cloning a deleted object.
+        :return: returns a fresh clone of the original object (with adjusted relations)
+        """
         if not self.pk:
             raise ValueError('Instance must be saved before it can be cloned')
 
-        if self.version_end_date:
-            raise ValueError('This is a historical item and can not be cloned.')
+        if self.version_end_date and not allow_restore:
+            raise ValueError('This is a historical item and can not be cloned.  Use restore() '
+                             'if you want to make it the current version')
 
-        if forced_version_date:
-            if not self.version_start_date <= forced_version_date <= get_utc_now():
+        now = get_utc_now()
+        if old_version_end_date:
+            if not self.version_start_date <= old_version_end_date <= now:
                 raise ValueError('The clone date must be between the version start date and now.')
         else:
-            forced_version_date = get_utc_now()
+            old_version_end_date = now
+
+        if new_version_start_date:
+            # if allow_restore and not self.is_current:
+            #     qs = self.__class__.objects.filter(identity=self.identity, version_end_date__isnull=False)
+            #     latest_end_date = qs.aggregate(Max('version_end_date'))['version_end_date']
+            # else:
+            #     latest_end_date = now
+            #
+            # if not new_version_start_date >= latest_end_date:
+            #     raise ValueError('It is not possible to use this new_version_start_date because a version '
+            #                      'already existed at that time')
+
+            if new_version_start_date < old_version_end_date:
+                raise ValueError('It is not possible to clone a version using a start time that is earlier '
+                                 'than the end time of the existing version')
+        else:
+            new_version_start_date = old_version_end_date
 
         earlier_version = self
 
         later_version = copy.copy(earlier_version)
         later_version.version_end_date = None
-        later_version.version_start_date = forced_version_date
+        later_version.version_start_date = new_version_start_date
 
         # set earlier_version's ID to a new UUID so the clone (later_version) can
         # get the old one -- this allows 'head' to always have the original
         # id allowing us to get at all historic foreign key relationships
         earlier_version.id = six.u(str(uuid.uuid4()))
-        earlier_version.version_end_date = forced_version_date
+        earlier_version.version_end_date = old_version_end_date
 
         if not in_bulk:
             # This condition might save us a lot of database queries if we are being called
@@ -1135,7 +1185,7 @@ class Versionable(models.Model):
         self.version_birth_date = self.version_start_date = timestamp
         return self
 
-    def clone_relations(self, clone, manager_field_name, forced_version_date):
+    def clone_relations(self, clone, manager_field_name, old_version_end_date, new_version_start_date):
         # Source: the original object, where relations are currently pointing to
         source = getattr(self, manager_field_name)  # returns a VersionedRelatedManager instance
         # Destination: the clone, where the cloned relations should point to
@@ -1152,7 +1202,11 @@ class Versionable(models.Model):
             # Only clone the relationship, if it is the current one; Simply adjust the older ones to point the old entry
             # Otherwise, the number of pointers pointing an entry will grow exponentially
             if rel.is_current:
-                later_current.append(rel.clone(forced_version_date=self.version_end_date, in_bulk=True))
+                later_current.append(rel._clone(
+                    old_version_end_date=old_version_end_date,
+                    new_version_start_date=new_version_start_date,
+                    in_bulk=True)
+                )
                 # On rel, which is no more 'current', set the source ID to self.id
                 setattr(rel, source.source_field_name, self)
             else:
@@ -1160,7 +1214,7 @@ class Versionable(models.Model):
         # Perform the bulk changes rel.clone() did not perform because of the in_bulk parameter
         # This saves a huge bunch of SQL queries:
         # - update current version entries
-        source.through.objects.filter(id__in=[l.id for l in later_current]).update(**{'version_start_date': forced_version_date})
+        source.through.objects.filter(id__in=[l.id for l in later_current]).update(**{'version_start_date': new_version_start_date})
         # - update entries that have been pointing the current object, but have never been 'current'
         source.through.objects.filter(id__in=[l.id for l in later_non_current]).update(**{source.source_field_name: self})
         # - create entries that were 'current', but which have been relieved in this method run

--- a/versions/models.py
+++ b/versions/models.py
@@ -1230,7 +1230,12 @@ class Versionable(models.Model):
         for field in cls._meta.local_fields:
             try:
                 if field.name not in Versionable.VERSIONABLE_FIELDS:
-                    setattr(restored, field.name, kwargs[field.name])
+                    value = kwargs[field.name]
+                    attr = field.name
+                    if isinstance(field, ForeignKey):
+                        if isinstance(value, six.string_types):
+                            attr += '_id'
+                    setattr(restored, attr, value)
 
             except KeyError:
                 if isinstance(field, ForeignKey):

--- a/versions_tests/apps.py
+++ b/versions_tests/apps.py
@@ -10,9 +10,14 @@ def index_adjustments(sender, using=None, **kwargs):
     :param str sender: database alias
     :param kwargs:
     """
-    from versions.util.postgresql import remove_uuid_id_like_indexes, create_current_version_unique_indexes
+    from versions.util.postgresql import (
+        remove_uuid_id_like_indexes,
+        create_current_version_unique_indexes,
+        create_current_version_unique_identity_indexes
+    )
     remove_uuid_id_like_indexes(sender.name, using)
     create_current_version_unique_indexes(sender.name, using)
+    create_current_version_unique_identity_indexes(sender.name, using)
 
 class VersionsTestsConfig(AppConfig):
     name = 'versions_tests'

--- a/versions_tests/models.py
+++ b/versions_tests/models.py
@@ -1,4 +1,5 @@
 from django.db.models import CharField, IntegerField, Model, ForeignKey
+from django.db.models.deletion import DO_NOTHING, PROTECT, SET, SET_NULL
 
 from versions.models import Versionable, VersionedManyToManyField, VersionedForeignKey
 
@@ -27,6 +28,7 @@ class B(Versionable):
 # Models for
 # - OneToManyTest
 # - PrefetchingTest
+# - DeletionHandlerTest
 class City(Versionable):
     name = CharField(max_length=200)
 
@@ -50,6 +52,38 @@ class Player(Versionable):
 class Award(Versionable):
     name = CharField(max_length=200)
     players = VersionedManyToManyField(Player, related_name='awards')
+
+
+class Mascot(Versionable):
+    name = CharField(max_length=200)
+    team = VersionedForeignKey(Team, null=False)
+
+    __str__ = versionable_description
+
+
+def default_team():
+    return Team.objects.current.get(name__startswith='default_team.')
+
+
+class Fan(Versionable):
+    name = CharField(max_length=200)
+    team = VersionedForeignKey(Team, null=False, on_delete=SET(default_team))
+
+    __str__ = versionable_description
+
+
+class RabidFan(Versionable):
+    name = CharField(max_length=200)
+    team = VersionedForeignKey(Team, null=True, on_delete=SET_NULL)
+
+    __str__ = versionable_description
+
+
+class WizardFan(Versionable):
+    name = CharField(max_length=200)
+    team = VersionedForeignKey(Team, null=True, on_delete=PROTECT)
+
+    __str__ = versionable_description
 
 
 ############################################

--- a/versions_tests/models.py
+++ b/versions_tests/models.py
@@ -86,6 +86,13 @@ class WizardFan(Versionable):
     __str__ = versionable_description
 
 
+class NonFan(Versionable):
+    name = CharField(max_length=200)
+    team = VersionedForeignKey(Team, null=False, on_delete=DO_NOTHING)
+
+    __str__ = versionable_description
+
+
 ############################################
 # SelfOneToManyTest models
 class Directory(Versionable):

--- a/versions_tests/models.py
+++ b/versions_tests/models.py
@@ -29,6 +29,7 @@ class B(Versionable):
 # - OneToManyTest
 # - PrefetchingTest
 # - DeletionHandlerTest
+# - VersionRestoreTest
 class City(Versionable):
     name = CharField(max_length=200)
 

--- a/versions_tests/tests/test_models.py
+++ b/versions_tests/tests/test_models.py
@@ -2129,7 +2129,7 @@ class VersionRestoreTest(TestCase):
         }
         self.forty_niners = forty_niners
 
-    def testRestoreLatestVersion(self):
+    def test_restore_latest_version(self):
         self.setup_common()
         self.player1.delete()
         deleted_at = self.player1.version_end_date
@@ -2150,7 +2150,7 @@ class VersionRestoreTest(TestCase):
         self.assertSetEqual(set(previous.awards.all()), set(self.awards.values()))
         self.assertEqual(self.forty_niners, previous.team)
 
-    def testRestorePreviousVersion(self):
+    def test_restore_previous_version(self):
         self.setup_common()
         p1 = self.player1.clone()
         p1.name = 'Joe'
@@ -2176,7 +2176,7 @@ class VersionRestoreTest(TestCase):
         self.assertSetEqual(set(previous.awards.all()), set(self.awards.values()))
         self.assertEqual(self.forty_niners, previous.team)
 
-    def testRestoreWithRequiredForeignKey(self):
+    def test_restore_with_required_foreignkey(self):
         team = Team.objects.create(name="Flying Pigs")
         mascot_v1 = Mascot.objects.create(name="Curly", team=team)
         mascot_v1.delete()
@@ -2206,7 +2206,7 @@ class VersionRestoreTest(TestCase):
         self.assertEqual(4, Mascot.objects.filter(name=mascot2_v1.name).count())
         self.assertEqual(team, rerestored.team)
 
-    def testOverTime(self):
+    def test_over_time(self):
         team1 = Team.objects.create(name='team1.v1')
         team2 = Team.objects.create(name='team2.v1')
         p1 = Player.objects.create(name='p1.v1', team=team1)

--- a/versions_tests/tests/test_models.py
+++ b/versions_tests/tests/test_models.py
@@ -274,51 +274,6 @@ class VersionNavigationTest(TestCase):
 
         self.assertRaises(ObjectDoesNotExist, lambda: B.objects.next_version(v3))
 
-    def test_getting_two_next_versions(self):
-        """
-        This should never happen, unless something went wrong REALLY bad;
-        For setting up this test case, we have to go under the hood of CleanerVersion and modify some timestamps.
-        Only like this it is possible to have two versions that follow one first version.
-        """
-        v1 = B.objects.as_of(self.t1).first()
-        v2 = B.objects.as_of(self.t2).first()
-        v3 = B.objects.as_of(self.t3).first()
-
-        v3.version_start_date = v2.version_start_date
-        v3.save()
-
-        self.assertRaises(MultipleObjectsReturned, lambda: B.objects.next_version(v1))
-
-    def test_getting_nonexistent_previous_version(self):
-        """
-        Raise an error when trying to look up the previous version of a version floating in emptyness.
-        This test case implies BAD modification under the hood of CleanerVersion, interrupting the continuity of an
-        object's versions through time.
-        """
-        v1 = B.objects.as_of(self.t1).first()
-        v2 = B.objects.as_of(self.t2).first()
-        v3 = B.objects.as_of(self.t3).first()
-
-        v2.version_end_date = v1.version_end_date
-        v2.save()
-
-        self.assertRaises(ObjectDoesNotExist, lambda: B.objects.previous_version(v3))
-
-    def test_getting_two_previous_versions(self):
-        """
-        This should never happen, unless something went wrong REALLY bad;
-        For setting up this test case, we have to go under the hood of CleanerVersion and modify some timestamps.
-        Only like this it is possible to have two versions that precede one last version.
-        """
-        v1 = B.objects.as_of(self.t1).first()
-        v2 = B.objects.as_of(self.t2).first()
-        v3 = B.objects.as_of(self.t3).first()
-
-        v1.version_end_date = v2.version_end_date
-        v1.save()
-
-        self.assertRaises(MultipleObjectsReturned, lambda: B.objects.previous_version(v3))
-
 
 class HistoricObjectsHandling(TestCase):
     t0 = datetime.datetime(1980, 1, 1, tzinfo=utc)

--- a/versions_tests/tests/test_models.py
+++ b/versions_tests/tests/test_models.py
@@ -19,6 +19,7 @@ from unittest import skip, skipUnless
 import re
 import uuid
 
+from django import get_version
 from django.core.exceptions import SuspiciousOperation, ObjectDoesNotExist, ValidationError
 from django.db import connection, IntegrityError, transaction
 from django.db.models import Q, Count, Sum
@@ -1996,7 +1997,7 @@ class SpecifiedUUIDTest(TestCase):
 
         # Postgresql will provide protection here, since util.postgresql.create_current_version_unique_identity_indexes
         # has been invoked in the post migration handler.
-        if connection.vendor == 'postgresql':
+        if connection.vendor == 'postgresql' and get_version() >= '1.7':
             with self.assertRaises(IntegrityError):
                 with transaction.atomic():
                     Person.objects.create(forced_identity=p.identity, name="Alexis")

--- a/versions_tests/tests/test_models.py
+++ b/versions_tests/tests/test_models.py
@@ -2083,6 +2083,8 @@ class VersionRestoreTest(TestCase):
         team = Team.objects.create(name="Flying Pigs")
         mascot_v1 = Mascot.objects.create(name="Curly", team=team)
         mascot_v1.delete()
+
+        # Restoring without supplying a value for the required foreign key will fail.
         with self.assertRaises(ForeignKeyRequiresValueError):
             mascot_v1.restore()
 
@@ -2096,7 +2098,13 @@ class VersionRestoreTest(TestCase):
         self.assertEqual(2, Mascot.objects.filter(name=mascot2_v1.name).count())
         self.assertEqual(1, Mascot.objects.current.filter(name=mascot2_v1.name).count())
 
+        # If a value (object or pk) is supplied, the restore will succeed.
         team2 = Team.objects.create(name="Submarine Sandwiches")
         restored = mascot2_v1.restore(team=team2)
         self.assertEqual(3, Mascot.objects.filter(name=mascot2_v1.name).count())
         self.assertEqual(team2, restored.team)
+
+        restored.delete()
+        rerestored = mascot2_v1.restore(team=team.pk)
+        self.assertEqual(4, Mascot.objects.filter(name=mascot2_v1.name).count())
+        self.assertEqual(team, rerestored.team)

--- a/versions_tests/tests/test_utils.py
+++ b/versions_tests/tests/test_utils.py
@@ -81,6 +81,14 @@ class PostgresqlVersionUniqueTests(TransactionTestCase):
             door_color = sb4.door_color
         )
 
+    def test_identity_unique(self):
+        c = Color.objects.create(name='sky blue')
+        c.identity = self.green.identity
+
+        # It should not be possible to have two "current" objects with the same identity:
+        with self.assertRaises(IntegrityError):
+            c.save()
+
 
 @skipUnless(AT_LEAST_17 and connection.vendor == 'postgresql', "Postgresql-specific test")
 class PostgresqlUuidLikeIndexesTest(TestCase):


### PR DESCRIPTION
Allow restoring versions.

When I started, I thought that 50a5369  (allow specifying id and identity at creation time) was necessary to implement this feature.  It turns out not to be necessary, but seems like it could be useful (we considered using it in our project).

The deletion handling stuff ensures that related versions, including many-to-many, are properly deleted when a version is deleted.  This seems  important for correct behaviour when versions can be restored.
