### PR TITLE
Django18 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,14 @@ env:
   - TOX_ENV=py27-django16-sqlite
   - TOX_ENV=py27-django17-pg
   - TOX_ENV=py27-django17-sqlite
+  - TOX_ENV=py27-django18-pg
+  - TOX_ENV=py27-django18-sqlite
   - TOX_ENV=py34-django16-pg
   - TOX_ENV=py34-django16-sqlite
   - TOX_ENV=py34-django17-pg
   - TOX_ENV=py34-django17-sqlite
+  - TOX_ENV=py34-django18-pg
+  - TOX_ENV=py34-django18-sqlite
 
 # Enable PostgreSQL usage
 addons:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ If you get errors, check the following things:
 """
 
 setup(name='CleanerVersion',
-      version='1.4.0',
+      version='1.4.1',
       description='A versioning solution for relational data models using the Django ORM',
       long_description='CleanerVersion is a solution that allows you to read and write multiple versions of an entry '
                        'to and from your relational database. It allows to keep track of modifications on an object '

--- a/tox.ini
+++ b/tox.ini
@@ -5,13 +5,14 @@
 
 [tox]
 envlist =
-	py{27,34}-django{16,17}-{sqlite,pg}
+	py{27,34}-django{16,17,18}-{sqlite,pg}
 
 [testenv]
 deps =
 	coverage
 	django16: django>=1.6,<1.7
 	django17: django>=1.7,<1.8
+	django18: https://github.com/django/django/archive/stable/1.8.x.zip
 	pg: psycopg2
 commands =
 	pg: coverage run --source=versions ./manage.py test --settings={env:TOX_PG_CONF:cleanerversion.settings.pg}

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
 	coverage
 	django16: django>=1.6,<1.7
 	django17: django>=1.7,<1.8
-	django18: https://github.com/django/django/archive/stable/1.8.x.zip
+	django18: django>=1.8,<1.9
 	pg: psycopg2
 commands =
 	pg: coverage run --source=versions ./manage.py test --settings={env:TOX_PG_CONF:cleanerversion.settings.pg}

--- a/versions/deletion.py
+++ b/versions/deletion.py
@@ -1,3 +1,4 @@
+from django import VERSION
 from django.db.models.deletion import (
     attrgetter, signals, six, sql, transaction,
     CASCADE,
@@ -134,7 +135,11 @@ class VersionedCollector(Collector):
         Gets a QuerySet of current objects related to ``objs`` via the relation ``related``.
 
         """
-        return related.model._base_manager.current.using(self.using).filter(
+        if VERSION >= (1, 8):
+            related_model = related.related_model
+        else:
+            related_model = related.model
+        return related_model._base_manager.current.using(self.using).filter(
             **{"%s__in" % related.field.name: objs}
         )
 

--- a/versions/deletion.py
+++ b/versions/deletion.py
@@ -41,7 +41,7 @@ class VersionedCollector(Collector):
         # end of a transaction.
         self.sort()
 
-        with transaction.commit_on_success_unless_managed(using=self.using):
+        with transaction.atomic(using=self.using, savepoint=False):
             # send pre_delete signals, but not for versionables
             for model, obj in self.instances_with_model():
                 if not model._meta.auto_created:

--- a/versions/models.py
+++ b/versions/models.py
@@ -18,6 +18,8 @@ import uuid
 from collections import namedtuple
 from django import VERSION
 
+if VERSION[:2] >= (1, 8):
+    from django.db.models.sql.datastructures import Join
 if VERSION[:2] >= (1, 7):
     from django.apps.registry import apps
 from django.core.exceptions import SuspiciousOperation, MultipleObjectsReturned, ObjectDoesNotExist
@@ -184,7 +186,7 @@ class VersionManager(models.Manager):
 class VersionedWhereNode(WhereNode):
     def as_sql(self, qn, connection):
         """
-        :param qn: In Django 1.7 this is a compiler; in 1.6, it's an instance-method
+        :param qn: In Django 1.7 & 1.8 this is a compiler; in 1.6, it's an instance-method
         :param connection: A DB connection
         :return: A tuple consisting of (sql_string, result_params)
         """
@@ -192,20 +194,32 @@ class VersionedWhereNode(WhereNode):
         for child in self.children:
             if isinstance(child, VersionedExtraWhere) and not child.params:
                 try:
-                    # Django 1.7 handles compilers as objects
+                    # Django 1.7 & 1.8 handles compilers as objects
                     _query = qn.query
                 except AttributeError:
                     # Django 1.6 handles compilers as instancemethods
                     _query = qn.__self__.query
                 query_time = _query.querytime.time
                 apply_query_time = _query.querytime.active
-                # Use the join_map to know, what *table* gets joined to which
+                # In Django 1.6 & 1.7, use the join_map to know, what *table* gets joined to which
                 # *left-hand sided* table
-                for lhs, table, join_cols in _query.join_map:
-                    if (lhs == child.alias and table == child.related_alias) \
+                # In Django 1.8, use the Join objects in alias_map
+                if hasattr(_query, 'join_map'):
+                    for lhs, table, join_cols in _query.join_map:
+                        if (lhs == child.alias and table == child.related_alias) \
+                                or (lhs == child.related_alias and table == child.alias):
+                            child.set_joined_alias(table)
+                            break
+                else:
+                    for table in _query.alias_map:
+                        join = _query.alias_map[table]
+                        if not isinstance(join, Join):
+                            continue
+                        lhs = join.parent_alias
+                        if (lhs == child.alias and table == child.related_alias) \
                             or (lhs == child.related_alias and table == child.alias):
-                        child.set_joined_alias(table)
-                        break
+                            child.set_joined_alias(table)
+                            break
                 if apply_query_time:
                     # Add query parameters that have not been added till now
                     child.set_as_of(query_time)

--- a/versions/models.py
+++ b/versions/models.py
@@ -795,7 +795,7 @@ class VersionedForeignRelatedObjectsDescriptor(ForeignRelatedObjectsDescriptor):
 
                 # This is a hack, in order to get the versioned related objects
                 for key in self.core_filters.keys():
-                    if '__exact' in key:
+                    if '__exact' in key or '__' not in key:
                         self.core_filters[key] = instance.identity
 
             def get_queryset(self):

--- a/versions_tests/tests/test_models.py
+++ b/versions_tests/tests/test_models.py
@@ -412,6 +412,10 @@ class OneToManyTest(TestCase):
         # We didn't change anything to the players so there must be 2 players in
         # the team at time t1...
         team_at_t1 = Team.objects.as_of(t1).first()
+        # TODO: Remove the following (useless) line, once Django1.8 is working
+        t1_player_queryset = team_at_t1.player_set.all()
+        # TODO: [django18 compat] The SQL query in t1_player_queryset.query shows that the Team pk value (team_at_t1.id)
+        # is used to look up the players (instead of the identity property value (team_at_t1.identity))
         self.assertEqual(2, team_at_t1.player_set.count())
 
         # ... and at time t2


### PR DESCRIPTION
Django 1.8 joins tables in a slightly differing manner than prior versions.
Also, it uses the 'atomic' method instead of the temporary 'commit_on_success_unless_managed'.'.