### PR TITLE
Django18 compatibility

### DIFF
--- a/versions/models.py
+++ b/versions/models.py
@@ -853,7 +853,11 @@ def create_versioned_many_related_manager(superclass, rel):
                 version_start_date_field = self.through._meta.get_field('version_start_date')
                 version_end_date_field = self.through._meta.get_field('version_end_date')
             except FieldDoesNotExist as e:
-                print(str(e) + "; available fields are " + ", ".join(self.through._meta.get_all_field_names()))
+                if VERSION[:2] >= (1, 8):
+                    fields = [f.name for f in self.through._meta.get_fields()]
+                else:
+                    fields =  self.through._meta.get_all_field_names()
+                print(str(e) + "; available fields are " + ", ".join(fields))
                 raise e
                 # FIXME: this probably does not work when auto-referencing
 

--- a/versions/util/postgresql.py
+++ b/versions/util/postgresql.py
@@ -116,7 +116,7 @@ def create_current_version_unique_indexes(app_name, database=None):
                 col_prefixes = []
                 columns = []
                 for field in group:
-                    column = model._meta.get_field_by_name(field)[0].column
+                    column = model._meta.get_field(field).column
                     col_prefixes.append(column[0:3])
                     columns.append(column)
                 index_name = '%s_%s_%s_v_uniq' % (app_name, table_name, '_'.join(col_prefixes))

--- a/versions_tests/tests/test_models.py
+++ b/versions_tests/tests/test_models.py
@@ -27,6 +27,7 @@ from django.db.models.deletion import ProtectedError
 from django.test import TestCase
 from django.utils.timezone import utc
 from django.utils import six
+from django import VERSION
 
 from versions.exceptions import DeletionOfNonCurrentVersionError
 from versions.models import get_utc_now, ForeignKeyRequiresValueError, Versionable
@@ -37,7 +38,13 @@ from versions_tests.models import (
 
 
 def get_relation_table(model_class, fieldname):
-    field_object, model, direct, m2m = model_class._meta.get_field_by_name(fieldname)
+
+    if VERSION[:2] >= (1, 8):
+        field_object = model_class._meta.get_field(fieldname)
+        direct = not field_object.auto_created or field_object.concrete
+    else:
+        field_object, _, direct, _ = model_class._meta.get_field_by_name(fieldname)
+
     if direct:
         field = field_object
     else:

--- a/versions_tests/tests/test_models.py
+++ b/versions_tests/tests/test_models.py
@@ -257,7 +257,7 @@ class DeletionHandlerTest(TestCase):
         self.assertEqual(1, City.objects.current.filter(pk=self.city.pk).count())
 
     def test_deleting_when_m2m_history(self):
-        through = Award._meta.get_field_by_name('players')[0].rel.through
+        through = Award._meta.get_field('players').rel.through
         a1 = Award.objects.create(name="bravo")
         p1 = Player.objects.create(name="Jessie")
         a1.players = [p1]
@@ -2307,7 +2307,7 @@ class VersionRestoreTest(TestCase):
         self.assertEqual(1, Team.objects.filter(name='team2.v1').count())
         self.assertEqual(3, Player.objects.filter(identity=p1.identity).count())
         self.assertEqual(1, Player.objects.filter(name='p2.v1').count())
-        m2m_manager = Award._meta.get_field_by_name('players')[0].rel.through.objects
+        m2m_manager = Award._meta.get_field('players').rel.through.objects
         self.assertEqual(1, m2m_manager.all().count())
 
 class DetachTest(TestCase):


### PR DESCRIPTION
Here are a few changes to remove uses of deprecated methods for 1.8+.  There were also some uses of _meta.get_field_by_name()[0] that have now been replaced by _meta.get_field().
