### PR TITLE
Do not use access attributes of django.conf.settings in module scope

### DIFF
--- a/versions/models.py
+++ b/versions/models.py
@@ -574,7 +574,8 @@ class VersionedQuerySet(QuerySet):
         del_query.query.select_related = False
         del_query.query.clear_ordering(force_empty=True)
 
-        collector = versions_settings.VERSIONED_DELETE_COLLECTOR_CLASS(using=del_query.db)
+        collector_class = versions_settings.get_versioned_delete_collector_class()
+        collector = collector_class(using=del_query.db)
         collector.collect(del_query)
         collector.delete(get_utc_now())
 
@@ -1146,7 +1147,8 @@ class Versionable(models.Model):
             "{} object can't be deleted because its {} attribute is set to None.".format(
                 self._meta.object_name, self._meta.pk.attname)
 
-        collector = versions_settings.VERSIONED_DELETE_COLLECTOR_CLASS(using=using)
+        collector_class = versions_settings.get_versioned_delete_collector_class()
+        collector = collector_class(using=using)
         collector.collect([self])
         collector.delete(get_utc_now())
 

--- a/versions/settings.py
+++ b/versions/settings.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.utils import importlib
+import importlib
 
 
 def import_from_string(val, setting_name):

--- a/versions/settings.py
+++ b/versions/settings.py
@@ -16,7 +16,21 @@ def import_from_string(val, setting_name):
         raise ImportError("Could not import '{}' for CleanerVersion setting '{}'. {}: {}.".format(
             (val, setting_name, e.__class__.__name__, e)))
 
-VERSIONED_DELETE_COLLECTOR_CLASS = import_from_string(
-    getattr(settings, 'VERSIONED_DELETE_COLLECTOR', 'versions.deletion.VersionedCollector'),
-    'VERSIONED_DELETE_COLLECTOR'
-)
+_cache = {}
+def get_versioned_delete_collector_class():
+    """
+    Gets the class to use for deletion collection.
+
+    This is done as a method instead of just defining a module-level variable because
+    Django doesn't like attributes of the django.conf.settings object to be accessed
+    in top-level module scope.
+
+    :return: class
+    """
+    key = 'VERSIONED_DELETE_COLLECTOR'
+    try:
+        cls = _cache[key]
+    except KeyError:
+        cls = import_from_string(getattr(settings, key, 'versions.deletion.VersionedCollector'), key)
+        _cache[key] = cls
+    return cls

--- a/versions/settings.py
+++ b/versions/settings.py
@@ -17,13 +17,13 @@ def import_from_string(val, setting_name):
             (val, setting_name, e.__class__.__name__, e)))
 
 _cache = {}
+_defaults = {
+    'VERSIONED_DELETE_COLLECTOR': 'versions.deletion.VersionedCollector'
+}
+
 def get_versioned_delete_collector_class():
     """
     Gets the class to use for deletion collection.
-
-    This is done as a method instead of just defining a module-level variable because
-    Django doesn't like attributes of the django.conf.settings object to be accessed
-    in top-level module scope.
 
     :return: class
     """
@@ -31,6 +31,25 @@ def get_versioned_delete_collector_class():
     try:
         cls = _cache[key]
     except KeyError:
-        cls = import_from_string(getattr(settings, key, 'versions.deletion.VersionedCollector'), key)
+        collector_class_string = get_setting(key)
+        cls = import_from_string(collector_class_string, key)
         _cache[key] = cls
     return cls
+
+def get_setting(setting_name):
+    """
+    Gets a setting from django.conf.settings if set, otherwise from the defaults
+    defined in this module.
+
+    A function is used for this instead of just defining a module-level variable because
+    Django doesn't like attributes of the django.conf.settings object to be accessed in
+    module scope.
+
+    :param string setting_name: setting to take from django.conf.setting
+    :return: class
+    """
+    try:
+        return getattr(settings, setting_name)
+    except AttributeError:
+        return _defaults[setting_name]
+


### PR DESCRIPTION
I just noticed this: https://docs.djangoproject.com/en/1.8/internals/contributing/writing-code/coding-style/#use-of-django-conf-settings ; this patch avoids the problem.