### PR TITLE
Changed PIP classifiers from beta to stable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name='CleanerVersion',
       url='https://github.com/swisscom/cleanerversion',
       install_requires=['django'],
       classifiers=[
-          'Development Status :: 4 - Beta',
+          'Development Status :: 5 - Production/Stable',
           'Framework :: Django',
           'Intended Audience :: Developers',
           'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
Things are very stable in the terms of the code base. I'm proposing moving from Beta to Stable in the `setup.py` file so it indicated as such in PyPi and on DjangoPackages.