### PR TITLE
Use django uuid field

### DIFF
--- a/docs/doc/historization_with_cleanerversion.rst
+++ b/docs/doc/historization_with_cleanerversion.rst
@@ -700,6 +700,34 @@ end date, and the version start date show in the change view. These fields are `
 Out of the box, VersionedAdmin allows for filtering the change view by the ``as_of`` queryset filter, and whether the
 object is current.
 
+Upgrade notes
+=============
+CleanerVersion 1.6.0 / Django 1.8.3
+-----------------------------------
+Starting with CleanerVersion 1.6.0, Django's ``UUIDField`` will be used for the ``id``, ``identity``,
+and ``VersionedForeignKey`` columns if the Django version is 1.8.3 or greater.
+
+If you are upgrading from lower versions of CleanerVersion or Django, you have two choices:
+
+1. Add a setting to your project so that CleanerVersion will continue to use ``CharField`` for ``Versionable``'s
+   UUID fields. Add this to your project's settings::
+
+       VERSIONS_USE_UUIDFIELD = False
+
+This value defaults to ``True`` if not explicitly set when using Django >= 1.8.3.
+
+2. Convert all of the relevant database fields to the type and size that Django uses for UUID fields for the
+   database that you are using.  This may be possible using Django's migrations, or could be done manually by
+   altering the column type as necessary for your database type for all the  ``id``, ``identity``, and
+   foreign key columns of your ``Versionable`` models (don't forget the auto-generated many-to-many tables).
+   This is not a trivial undertaking; it will involve for example dropping and recreating constraints.
+   An example of column altering syntax for PostgreSQL::
+
+       ALTER TABLE blog_author ALTER COLUMN id type uuid USING id:uuid;
+       ALTER TABLE blog_author ALTER COLUMN identity type uuid USING identity:uuid;
+
+You must choose one or the other solution; not doing so will result in your application no longer working.
+
 Known Issues
 ============
 

--- a/versions/settings.py
+++ b/versions/settings.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 import importlib
+from django import VERSION
 
 
 def import_from_string(val, setting_name):
@@ -52,4 +53,6 @@ def get_setting(setting_name):
         return getattr(settings, setting_name)
     except AttributeError:
         return _defaults[setting_name]
+
+use_uuidfield = VERSION[:3] >= (1,8,3)
 

--- a/versions/settings.py
+++ b/versions/settings.py
@@ -1,6 +1,37 @@
-from django.conf import settings
+from django.conf import settings as django_settings
 import importlib
 from django import VERSION
+
+
+_cache = {}
+
+
+class VersionsSettings(object):
+    """
+    Gets a setting from django.conf.settings if set, otherwise from the defaults
+    defined in this class.
+
+    A magic accessor is used instead of just defining module-level variables because
+    Django doesn't like attributes of the django.conf.settings object to be accessed in
+    module scope.
+    """
+
+    defaults = {
+        'VERSIONED_DELETE_COLLECTOR': 'versions.deletion.VersionedCollector',
+        'VERSIONS_USE_UUIDFIELD': VERSION[:3] >= (1, 8, 3),
+    }
+
+    def __getattr__(self, name):
+        try:
+            return getattr(django_settings, name)
+        except AttributeError:
+            try:
+                return self.defaults[name]
+            except KeyError:
+                raise AttributeError("{} object has no attribute {}".format(self.__class__, name))
+
+
+settings = VersionsSettings()
 
 
 def import_from_string(val, setting_name):
@@ -17,10 +48,6 @@ def import_from_string(val, setting_name):
         raise ImportError("Could not import '{}' for CleanerVersion setting '{}'. {}: {}.".format(
             (val, setting_name, e.__class__.__name__, e)))
 
-_cache = {}
-_defaults = {
-    'VERSIONED_DELETE_COLLECTOR': 'versions.deletion.VersionedCollector'
-}
 
 def get_versioned_delete_collector_class():
     """
@@ -32,27 +59,7 @@ def get_versioned_delete_collector_class():
     try:
         cls = _cache[key]
     except KeyError:
-        collector_class_string = get_setting(key)
+        collector_class_string = getattr(settings, key)
         cls = import_from_string(collector_class_string, key)
         _cache[key] = cls
     return cls
-
-def get_setting(setting_name):
-    """
-    Gets a setting from django.conf.settings if set, otherwise from the defaults
-    defined in this module.
-
-    A function is used for this instead of just defining a module-level variable because
-    Django doesn't like attributes of the django.conf.settings object to be accessed in
-    module scope.
-
-    :param string setting_name: setting to take from django.conf.setting
-    :return: class
-    """
-    try:
-        return getattr(settings, setting_name)
-    except AttributeError:
-        return _defaults[setting_name]
-
-use_uuidfield = VERSION[:3] >= (1,8,3)
-

--- a/versions_tests/tests/test_models.py
+++ b/versions_tests/tests/test_models.py
@@ -2165,15 +2165,15 @@ class SpecifiedUUIDTest(TestCase):
 
     @staticmethod
     def uuid4():
-        return six.text_type(str(uuid.uuid4()))
+        return uuid.uuid4()
 
     def test_create_with_uuid(self):
         p_id = self.uuid4()
         p = Person.objects.create(id=p_id, name="Alice")
-        self.assertEqual(p_id, p.id)
-        self.assertEqual(p_id, p.identity)
+        self.assertEqual(str(p_id), str(p.id))
+        self.assertEqual(str(p_id), str(p.identity))
 
-        p_id = six.text_type(str(uuid.uuid5(uuid.NAMESPACE_OID, 'bar')))
+        p_id = uuid.uuid5(uuid.NAMESPACE_OID, 'bar')
         with self.assertRaises(ValueError):
             Person.objects.create(id=p_id, name="Alexis")
 


### PR DESCRIPTION
This allows using Django's UUID field, and will do so by default if the Django version is 1.8.3 or greater.