### PR TITLE
Fix for ForeignKey filter nonversioned to versioned(Issue 57) as well as the restore button in the Admin

### DIFF
--- a/versions/admin.py
+++ b/versions/admin.py
@@ -166,18 +166,31 @@ class VersionedAdmin(admin.ModelAdmin):
         return list_filter + (('version_start_date', DateTimeFilter), IsCurrentFilter)
 
     def restore(self,request, *args, **kwargs):
-        return True
+        """
+        View for restoring object from change view
+        """
+        paths = request.path_info.split('/')
+        object_id_index = paths.index("restore") - 1
+        object_id = paths[object_id_index]
+
+        obj = super(VersionedAdmin,self).get_object(request, object_id)
+        obj.restore()
+        admin_wordIndex = object_id_index - 3
+        path = "/%s" % ("/".join(paths[admin_wordIndex:object_id_index]))
+        return HttpResponseRedirect(path)
 
     def will_not_clone(self, request, *args, **kwargs):
         """
         Add save but not clone capability in the changeview
         """
         paths = request.path_info.split('/')
-
-        object_id = paths[3]
+        index_of_object_id = paths.index("will_not_clone")-1
+        object_id = paths[index_of_object_id]
         self.change_view(request, object_id)
+
+        admin_wordInUrl = index_of_object_id-3
         # This gets the adminsite for the app, and the model name and joins together with /
-        path = '/' + '/'.join(paths[1:3])
+        path = '/' + '/'.join(paths[admin_wordInUrl:index_of_object_id])
         return HttpResponseRedirect(path)
 
     @property
@@ -200,7 +213,8 @@ class VersionedAdmin(admin.ModelAdmin):
         """
         obj = super(VersionedAdmin, self).get_object(request, object_id)  # from_field breaks in 1.7.8
         # Only clone if update view as get_object() is also called for change, delete, and history views
-        if request.method == 'POST' and obj and obj.is_latest and 'will_not_clone' not in request.path and 'delete' not in request.path:
+        if request.method == 'POST' and obj and obj.is_latest and 'will_not_clone' not in request.path \
+                and 'delete' not in request.path and 'restore' not in request.path:
             obj = obj.clone()
 
         return obj
@@ -242,7 +256,8 @@ class VersionedAdmin(admin.ModelAdmin):
         Appends the custom will_not_clone url to the admin site
         """
         not_clone_url = [url(r'^(.+)/will_not_clone/$', admin.site.admin_view(self.will_not_clone))]
-        return not_clone_url + super(VersionedAdmin, self).get_urls()
+        restore_url = [url(r'^(.+)/restore/$', admin.site.admin_view(self.restore))]
+        return not_clone_url + restore_url + super(VersionedAdmin, self).get_urls()
 
     def is_current(self, obj):
         return obj.is_current

--- a/versions/models.py
+++ b/versions/models.py
@@ -383,7 +383,7 @@ class VersionedExtraWhere(ExtraWhere):
         if self._joined_alias:
             sql = sql.format(alias=self._joined_alias)
         else:
-            pass
+            pass #was erroring when filtering on a Foreign key off of a models.Model class
 
         # Set the final sqls
         # self.sqls needs to be set before the call to parent

--- a/versions/models.py
+++ b/versions/models.py
@@ -382,8 +382,7 @@ class VersionedExtraWhere(ExtraWhere):
         # By here, the sql string is defined if an as_of_time was provided
         if self._joined_alias:
             sql = sql.format(alias=self._joined_alias)
-        else:
-            pass #was erroring when filtering on a Foreign key off of a models.Model class
+
 
         # Set the final sqls
         # self.sqls needs to be set before the call to parent

--- a/versions/models.py
+++ b/versions/models.py
@@ -383,7 +383,7 @@ class VersionedExtraWhere(ExtraWhere):
         if self._joined_alias:
             sql = sql.format(alias=self._joined_alias)
         else:
-            raise ValueError("joined_alias not set")
+            pass
 
         # Set the final sqls
         # self.sqls needs to be set before the call to parent

--- a/versions/static/js/admin_addon.js
+++ b/versions/static/js/admin_addon.js
@@ -11,8 +11,8 @@ function update_document() {
 function make_restore_button(){
     (function($){
         if($('ul').hasClass('object-tools')){
-            if($('div.field-id p').text()!=$('div.field-identity p').text()) {
-                $('input[name="_addanother"]').before('<input formaction="restore/" type="submit" formmethod="POST" value="Restore"');
+            if($('div.field-is_current img').attr('alt').valueOf()=="False"){
+                $('input[name="_addanother"]').before('<input formaction="restore/" type="submit" formmethod="POST" value="Restore">');
             }
         }
     })(django.jQuery)

--- a/versions_tests/tests/test_models.py
+++ b/versions_tests/tests/test_models.py
@@ -2167,9 +2167,9 @@ class FilterOnForeignKeyRelationTest(TestCase):
         michael.save()
         baseball_hat.save()
         hat = WineDrinkerHat.objects.filter(wearer__name='michael')
-        self.assertEqual(hat, baseball_hat)
+        self.assertEqual(hat.pk, baseball_hat.pk)
         person = WineDrinker.objects.filter(hats__shape='baseball hat')
-        self.assertEqual(person, michael)
+        self.assertEqual(person.pk, michael.pk)
 
 class SpecifiedUUIDTest(TestCase):
 

--- a/versions_tests/tests/test_models.py
+++ b/versions_tests/tests/test_models.py
@@ -2166,9 +2166,9 @@ class FilterOnForeignKeyRelationTest(TestCase):
         baseball_hat = WineDrinkerHat.objects.create(shape='baseball hat', color='blue', wearer=michael)
         michael.save()
         baseball_hat.save()
-        hat = WineDrinkerHat.objects.filter(wearer__name='michael')
+        hat = WineDrinkerHat.objects.filter(wearer__name='michael').get()
         self.assertEqual(hat.pk, baseball_hat.pk)
-        person = WineDrinker.objects.filter(hats__shape='baseball hat')
+        person = WineDrinker.objects.filter(hats__shape='baseball hat').get()
         self.assertEqual(person.pk, michael.pk)
 
 class SpecifiedUUIDTest(TestCase):

--- a/versions_tests/tests/test_models.py
+++ b/versions_tests/tests/test_models.py
@@ -2161,6 +2161,16 @@ class FilterOnForeignKeyRelationTest(TestCase):
         l2 = len(Player.objects.as_of(t1).filter(team__name='team'))
         self.assertEqual(l1, l2)
 
+    def test_filter_on_fk_versioned_and_nonversioned_join(self):
+        michael = WineDrinker.objects.create(name='michael', glass_content=Wine.objects.create(name='Port',vintage='2013'))
+        baseball_hat = WineDrinkerHat.objects.create(shape='baseball hat', color='blue', wearer=michael)
+        michael.save()
+        baseball_hat.save()
+        hat = WineDrinkerHat.objects.filter(wearer__name='michael')
+        self.assertEqual(hat, baseball_hat)
+        person = WineDrinker.objects.filter(hats__shape='baseball hat')
+        self.assertEqual(person, michael)
+
 class SpecifiedUUIDTest(TestCase):
 
     @staticmethod


### PR DESCRIPTION
This is a fix for [Issue 57](https://github.com/swisscom/cleanerversion/issues/57) and also has my restore button admin addon.