### PR TITLE
Bugfix/nonversionedintegration

### DIFF
--- a/versions/models.py
+++ b/versions/models.py
@@ -383,7 +383,7 @@ class VersionedExtraWhere(ExtraWhere):
         if self._joined_alias:
             sql = sql.format(alias=self._joined_alias)
         else:
-            pass
+            pass #was erroring when filtering on a Foreign key off of a models.Model class
 
         # Set the final sqls
         # self.sqls needs to be set before the call to parent

--- a/versions/models.py
+++ b/versions/models.py
@@ -382,8 +382,7 @@ class VersionedExtraWhere(ExtraWhere):
         # By here, the sql string is defined if an as_of_time was provided
         if self._joined_alias:
             sql = sql.format(alias=self._joined_alias)
-        else:
-            pass #was erroring when filtering on a Foreign key off of a models.Model class
+
 
         # Set the final sqls
         # self.sqls needs to be set before the call to parent

--- a/versions/models.py
+++ b/versions/models.py
@@ -366,6 +366,10 @@ class VersionedExtraWhere(ExtraWhere):
         sql = ""
         params = []
 
+        # Fail fast for inacceptable cases
+        if self._as_of_time_set and not self._joined_alias:
+            raise ValueError("joined_alias is not set, but as_of is; this is a conflict!")
+
         # Set the SQL string in dependency of whether as_of_time was set or not
         if self._as_of_time_set:
             if self.as_of_time:
@@ -382,7 +386,6 @@ class VersionedExtraWhere(ExtraWhere):
         # By here, the sql string is defined if an as_of_time was provided
         if self._joined_alias:
             sql = sql.format(alias=self._joined_alias)
-
 
         # Set the final sqls
         # self.sqls needs to be set before the call to parent

--- a/versions/models.py
+++ b/versions/models.py
@@ -383,7 +383,7 @@ class VersionedExtraWhere(ExtraWhere):
         if self._joined_alias:
             sql = sql.format(alias=self._joined_alias)
         else:
-            raise ValueError("joined_alias not set")
+            pass
 
         # Set the final sqls
         # self.sqls needs to be set before the call to parent

--- a/versions_tests/tests/test_models.py
+++ b/versions_tests/tests/test_models.py
@@ -2167,9 +2167,9 @@ class FilterOnForeignKeyRelationTest(TestCase):
         michael.save()
         baseball_hat.save()
         hat = WineDrinkerHat.objects.filter(wearer__name='michael')
-        self.assertEqual(hat, baseball_hat)
+        self.assertEqual(hat.pk, baseball_hat.pk)
         person = WineDrinker.objects.filter(hats__shape='baseball hat')
-        self.assertEqual(person, michael)
+        self.assertEqual(person.pk, michael.pk)
 
 class SpecifiedUUIDTest(TestCase):
 

--- a/versions_tests/tests/test_models.py
+++ b/versions_tests/tests/test_models.py
@@ -2149,6 +2149,15 @@ class IntegrationNonVersionableModelsTests(TestCase):
         should_be_jacques_t1 = should_be_jacques.__class__.objects.as_of(self.t1).get(identity=should_be_jacques.identity)
         self.assertEqual(jacques_t1, should_be_jacques_t1)
 
+    def test_filter_on_fk_versioned_and_nonversioned_join(self):
+        # Get non-versioned objects, filtering on a FK-related versioned object
+        jacques_hats = WineDrinkerHat.objects.filter(wearer__name='Jacques').distinct()
+        self.assertEqual(set(jacques_hats), set([self.green_vagabond_hat, self.red_sailor_hat]))
+
+        # Get all versions of a Versionable by filtering on a FK-related non-versioned object
+        person_versions = WineDrinker.objects.filter(hats__shape='Vagabond')
+        self.assertIn(self.jacques, person_versions)
+
 
 class FilterOnForeignKeyRelationTest(TestCase):
     def test_filter_on_fk_relation(self):
@@ -2161,15 +2170,6 @@ class FilterOnForeignKeyRelationTest(TestCase):
         l2 = len(Player.objects.as_of(t1).filter(team__name='team'))
         self.assertEqual(l1, l2)
 
-    def test_filter_on_fk_versioned_and_nonversioned_join(self):
-        michael = WineDrinker.objects.create(name='michael', glass_content=Wine.objects.create(name='Port',vintage='2013'))
-        baseball_hat = WineDrinkerHat.objects.create(shape='baseball hat', color='blue', wearer=michael)
-        michael.save()
-        baseball_hat.save()
-        hat = WineDrinkerHat.objects.filter(wearer__name='michael').get()
-        self.assertEqual(hat.pk, baseball_hat.pk)
-        person = WineDrinker.objects.filter(hats__shape='baseball hat').get()
-        self.assertEqual(person.pk, michael.pk)
 
 class SpecifiedUUIDTest(TestCase):
 

--- a/versions_tests/tests/test_models.py
+++ b/versions_tests/tests/test_models.py
@@ -2166,9 +2166,9 @@ class FilterOnForeignKeyRelationTest(TestCase):
         baseball_hat = WineDrinkerHat.objects.create(shape='baseball hat', color='blue', wearer=michael)
         michael.save()
         baseball_hat.save()
-        hat = WineDrinkerHat.objects.filter(wearer__name='michael')
+        hat = WineDrinkerHat.objects.filter(wearer__name='michael').get()
         self.assertEqual(hat.pk, baseball_hat.pk)
-        person = WineDrinker.objects.filter(hats__shape='baseball hat')
+        person = WineDrinker.objects.filter(hats__shape='baseball hat').get()
         self.assertEqual(person.pk, michael.pk)
 
 class SpecifiedUUIDTest(TestCase):

--- a/versions_tests/tests/test_models.py
+++ b/versions_tests/tests/test_models.py
@@ -2161,6 +2161,16 @@ class FilterOnForeignKeyRelationTest(TestCase):
         l2 = len(Player.objects.as_of(t1).filter(team__name='team'))
         self.assertEqual(l1, l2)
 
+    def test_filter_on_fk_versioned_and_nonversioned_join(self):
+        michael = WineDrinker.objects.create(name='michael', glass_content=Wine.objects.create(name='Port',vintage='2013'))
+        baseball_hat = WineDrinkerHat.objects.create(shape='baseball hat', color='blue', wearer=michael)
+        michael.save()
+        baseball_hat.save()
+        hat = WineDrinkerHat.objects.filter(wearer__name='michael')
+        self.assertEqual(hat, baseball_hat)
+        person = WineDrinker.objects.filter(hats__shape='baseball hat')
+        self.assertEqual(person, michael)
+
 class SpecifiedUUIDTest(TestCase):
 
     @staticmethod


### PR DESCRIPTION
Refined PR #102 and integrated the proposed test to an already existing test-case doing already the same setup.
@boydjohnson Thanks for the test, there was definitely something behaving not quite correctly. I've taken it over and refined it a bit, by, for example, adding another version of the Versionable object.
Other than that, I've re-added, however, the validation check earlier in the model method, just to be sure. 
Let me know if you agree.
This PR replaces #102.