### PR TITLE
remove support for 1.6 and 1.7 (ref: #99)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,8 @@ language: python
 python: "2.7"
 
 env:
-  - TOX_ENV=py27-django16-pg
-  - TOX_ENV=py27-django16-sqlite
-  - TOX_ENV=py27-django17-pg
-  - TOX_ENV=py27-django17-sqlite
   - TOX_ENV=py27-django18-pg
   - TOX_ENV=py27-django18-sqlite
-  - TOX_ENV=py34-django16-pg
-  - TOX_ENV=py34-django16-sqlite
-  - TOX_ENV=py34-django17-pg
-  - TOX_ENV=py34-django17-sqlite
   - TOX_ENV=py34-django18-pg
   - TOX_ENV=py34-django18-sqlite
 

--- a/NOTICE
+++ b/NOTICE
@@ -4,6 +4,6 @@ Copyright 2014 Swisscom, Sophia Engineering
 This software contains code derived from DirtyVersion available at
 https://github.com/cordmata/dirtyversion
 
-This software was tested on Django 1.6 & 1.7 (https://www.djangoproject.com/)
+This software was tested on Django 1.8 (https://www.djangoproject.com/)
 
-This software is written in Python 2.7 (https://www.python.org/)
+This software is written for Python 2.7 and Python 3.4 (https://www.python.org/)

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,6 @@ relational database. It allows to keep track of modifications on an object over 
 
 CleanerVersion therefore enables a Django-based Datawarehouse, which was the initial idea of this package.
 
-
 Features
 ========
 
@@ -50,8 +49,16 @@ Prerequisites
 This code was tested with the following technical components
 
 * Python 2.7 & 3.4
-* Django 1.6, 1.7 & 1.8
+* Django 1.8
 * PostgreSQL 9.3.4 & SQLite3
+
+Older Django versions
+=====================
+CleanerVersion was originally written for Django 1.6.
+
+Old packages compatible with older Django releases:
+
+* Django 1.6 and 1.7: https://pypi.python.org/pypi/CleanerVersion/1.5.4
 
 
 Documentation

--- a/docs/doc/historization_with_cleanerversion.rst
+++ b/docs/doc/historization_with_cleanerversion.rst
@@ -3,7 +3,7 @@ Historization with CleanerVersion
 *********************************
 
 Disclaimer: This documentation as well as the CleanerVersion application code have been written to work against Django
-1.6.x, 1.7.x and 1.8.x. The documentation may not be accurate anymore when using more recent versions of Django.
+1.8.x. The documentation may not be accurate anymore when using more recent versions of Django.
 
 .. _cleanerversion-quick-starter:
 
@@ -746,9 +746,9 @@ Postgresql specific
 ===================
 
 Django creates `extra indexes <https://docs.djangoproject.com/en/1.7/ref/databases/#indexes-for-varchar-and-text-columns>`_
-for CharFields that are used for like queries (e.g. WHERE foo like 'fish%'). Since Django 1.6 and 1.7 do not support
-native database UUID fields, the UUID fields that are used for the id and identity columns of Versionable models have these extra
-indexes created.  In fact, these fields will never be compared using the like operator.  Leaving these indexes would create a
+for CharFields that are used for like queries (e.g. WHERE foo like 'fish%'). Since Django 1.6 (the version CleanerVersion originally
+targeted) did not have native database UUID fields, the UUID fields that are used for the id and identity columns of Versionable models
+have these extra indexes created.  In fact, these fields will never be compared using the like operator.  Leaving these indexes would create a
 performance penalty for inserts and updates, especially for larger tables.  ``versions.util.postgresql`` has a function
 ``remove_uuid_id_like_indexes`` that can be used to remove these extra indexes.
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,13 +5,11 @@
 
 [tox]
 envlist =
-	py{27,34}-django{16,17,18}-{sqlite,pg}
+	py{27,34}-django{18}-{sqlite,pg}
 
 [testenv]
 deps =
 	coverage
-	django16: django>=1.6,<1.7
-	django17: django>=1.7,<1.8
 	django18: django>=1.8,<1.9
 	pg: psycopg2
 commands =

--- a/versions/admin.py
+++ b/versions/admin.py
@@ -12,7 +12,6 @@ from django.contrib.admin.options import get_content_type_for_model
 from django.utils.encoding import force_text
 from django.utils.text import capfirst
 from django.template.response import TemplateResponse
-from django import VERSION
 from datetime import datetime
 
 class DateTimeFilterForm(forms.Form):
@@ -239,8 +238,7 @@ class VersionedAdmin(admin.ModelAdmin):
             content_type=get_content_type_for_model(model)
         ).select_related().order_by('action_time')
 
-        ctx = self.admin_site.each_context() if VERSION < (1, 8) \
-            else self.admin_site.each_context(request)
+        ctx = self.admin_site.each_context(request)
 
         context = dict(ctx,
                        title=('Change history: %s') % force_text(obj),

--- a/versions/models.py
+++ b/versions/models.py
@@ -18,12 +18,8 @@ import uuid
 from collections import namedtuple
 import re
 
-from django import VERSION
-
-if VERSION[:2] >= (1, 8):
-    from django.db.models.sql.datastructures import Join
-if VERSION[:2] >= (1, 7):
-    from django.apps.registry import apps
+from django.db.models.sql.datastructures import Join
+from django.apps.registry import apps
 from django.core.exceptions import SuspiciousOperation, ObjectDoesNotExist
 from django.db import transaction
 from django.db.models.base import Model
@@ -292,29 +288,18 @@ class VersionedWhereNode(WhereNode):
         to be able to add time restrictions for those tables based on the VersionedQuery's
         querytime value.
 
-        :param qn: In Django 1.7 & 1.8 this is a compiler; in 1.6, it's an instance-method
+        :param qn: In Django 1.7 & 1.8 this is a compiler
         :param connection: A DB connection
         :return: A tuple consisting of (sql_string, result_params)
         """
         # self.children is an array of VersionedExtraWhere-objects
         for child in self.children:
             if isinstance(child, VersionedExtraWhere) and not child.params:
-                try:
-                    # Django 1.7 & 1.8 handles compilers as objects
-                    _query = qn.query
-                except AttributeError:
-                    # Django 1.6 handles compilers as instancemethods
-                    _query = qn.__self__.query
+                _query = qn.query
                 query_time = _query.querytime.time
                 apply_query_time = _query.querytime.active
                 alias_map = _query.alias_map
-                # In Django 1.6 & 1.7, use the join_map to know, what *table* gets joined to which
-                # *left-hand sided* table
-                # In Django 1.8, use the Join objects in alias_map
-                if hasattr(_query, 'join_map'):
-                    self._set_child_joined_alias_using_join_map(child, _query.join_map, alias_map)
-                else:
-                    self._set_child_joined_alias(child, alias_map)
+                self._set_child_joined_alias(child, alias_map)
                 if apply_query_time:
                     # Add query parameters that have not been added till now
                     child.set_as_of(query_time)
@@ -322,32 +307,6 @@ class VersionedWhereNode(WhereNode):
                     # Remove the restriction if it's not required
                     child.sqls = []
         return super(VersionedWhereNode, self).as_sql(qn, connection)
-
-    @staticmethod
-    def _set_child_joined_alias_using_join_map(child, join_map, alias_map):
-        """
-        Set the joined alias on the child, for Django <= 1.7.x.
-        :param child:
-        :param join_map:
-        :param alias_map:
-        """
-        for lhs, table, join_cols in join_map:
-            if lhs is None:
-                continue
-            if lhs == child.alias:
-                relevant_alias = child.related_alias
-            elif lhs == child.related_alias:
-                relevant_alias = child.alias
-            else:
-                continue
-
-            join_info = alias_map[relevant_alias]
-            if join_info.join_type is None:
-                continue
-
-            if join_info.lhs_alias in [child.alias, child.related_alias]:
-                child.set_joined_alias(relevant_alias)
-                break
 
     @staticmethod
     def _set_child_joined_alias(child, alias_map):
@@ -582,23 +541,6 @@ class VersionedQuerySet(QuerySet):
         :param kwargs: Same as the original QuerySet._clone params
         :return: Just as QuerySet._clone, this method returns a clone of the original object
         """
-        if VERSION[:2] == (1, 6):
-            klass = kwargs.pop('klass', None)
-            # This patch was taken from Django 1.7 and is applied only in case we're using Django 1.6 and
-            # ValuesListQuerySet objects. Since VersionedQuerySet is not a subclass of ValuesListQuerySet, a new type
-            # inheriting from both is created and used as class.
-            # https://github.com/django/django/blob/1.7/django/db/models/query.py#L943
-            if klass and not issubclass(self.__class__, klass):
-                base_queryset_class = getattr(self, '_base_queryset_class', self.__class__)
-                class_bases = (klass, base_queryset_class)
-                class_dict = {
-                    '_base_queryset_class': base_queryset_class,
-                    '_specialized_queryset_class': klass,
-                }
-                kwargs['klass'] = type(klass.__name__, class_bases, class_dict)
-            else:
-                kwargs['klass'] = klass
-
         clone = super(VersionedQuerySet, self)._clone(**kwargs)
         clone.querytime = self.querytime
         return clone
@@ -796,7 +738,7 @@ class VersionedManyToManyField(ManyToManyField):
         # declared apps' models inside a __fake__ module.
         # This means that the models can be already loaded and registered by their original module, when we
         # reach this point of the application and therefore there is no need to load them a second time.
-        if VERSION[:2] >= (1, 7) and cls.__module__ == '__fake__':
+        if cls.__module__ == '__fake__':
             try:
                 # Check the apps for an already registered model
                 return apps.get_registered_model(cls._meta.app_label, str(name))
@@ -911,10 +853,7 @@ class VersionedForeignRelatedObjectsDescriptor(ForeignRelatedObjectsDescriptor):
                     with transaction.atomic(using=db, savepoint=False):
                         cloned_pks = [obj.clone().pk for obj in queryset]
                         update_qs = self.current.filter(pk__in=cloned_pks)
-                        if VERSION[:2] == (1, 6):
-                            update_qs.update(**{rel_field.name: None})
-                        else:
-                            self._clear(update_qs, bulk)
+                        self._clear(update_qs, bulk)
 
             if 'remove' in dir(manager_cls):
                 def remove(self, *objs):
@@ -955,10 +894,7 @@ def create_versioned_many_related_manager(superclass, rel):
                 version_start_date_field = self.through._meta.get_field('version_start_date')
                 version_end_date_field = self.through._meta.get_field('version_end_date')
             except FieldDoesNotExist as e:
-                if VERSION[:2] >= (1, 8):
-                    fields = [f.name for f in self.through._meta.get_fields()]
-                else:
-                    fields = self.through._meta.get_all_field_names()
+                fields = [f.name for f in self.through._meta.get_fields()]
                 print(str(e) + "; available fields are " + ", ".join(fields))
                 raise e
                 # FIXME: this probably does not work when auto-referencing
@@ -993,12 +929,8 @@ def create_versioned_many_related_manager(superclass, rel):
                 old_ids = set()
                 for obj in objs:
                     if isinstance(obj, self.model):
-                        # The Django 1.7-way is preferred
                         if hasattr(self, 'target_field'):
                             fk_val = self.target_field.get_foreign_related_value(obj)[0]
-                        # But the Django 1.6.x -way is supported for backward compatibility
-                        elif hasattr(self, '_get_fk_val'):
-                            fk_val = self._get_fk_val(obj, target_field_name)
                         else:
                             raise TypeError("We couldn't find the value of the foreign key, this might be due to the "
                                             "use of an unsupported version of Django")
@@ -1141,13 +1073,7 @@ class VersionedReverseManyRelatedObjectsDescriptor(ReverseManyRelatedObjectsDesc
 
         filter = Q(**{relation_manager.source_field.attname: instance.pk})
         qs = self.through.objects.current.filter(filter)
-        try:
-            # Django 1.7
-            target_name = relation_manager.target_field.attname
-        except AttributeError:
-            # Django 1.6
-            target_name = relation_manager.through._meta.get_field_by_name(
-                relation_manager.target_field_name)[0].attname
+        target_name = relation_manager.target_field.attname
         current_ids = set(qs.values_list(target_name, flat=True))
 
         being_removed = current_ids - new_ids

--- a/versions_tests/tests/test_utils.py
+++ b/versions_tests/tests/test_utils.py
@@ -1,5 +1,4 @@
 from unittest import skipUnless
-from django import VERSION
 from django.db import connection
 from django.test import TestCase, TransactionTestCase
 from django.db import IntegrityError
@@ -7,10 +6,7 @@ from versions_tests.models import ChainStore, Color
 from versions.util.postgresql import get_uuid_like_indexes_on_table
 
 
-AT_LEAST_17 = VERSION[:2] >= (1, 7)
-
-
-@skipUnless(AT_LEAST_17 and connection.vendor == 'postgresql', "Postgresql-specific test")
+@skipUnless(connection.vendor == 'postgresql', "Postgresql-specific test")
 class PostgresqlVersionUniqueTests(TransactionTestCase):
     def setUp(self):
         self.red = Color.objects.create(name='red')
@@ -90,7 +86,7 @@ class PostgresqlVersionUniqueTests(TransactionTestCase):
             c.save()
 
 
-@skipUnless(AT_LEAST_17 and connection.vendor == 'postgresql', "Postgresql-specific test")
+@skipUnless(connection.vendor == 'postgresql', "Postgresql-specific test")
 class PostgresqlUuidLikeIndexesTest(TestCase):
     def test_no_like_indexes_on_uuid_columns(self):
         # Django creates like indexes on char columns.  In Django 1.7.x and below, there is no


### PR DESCRIPTION
I suggest removing support for Django 1.6 and 1.7 in the master branch, and pointing people who want to use it with Django 1.6 or 1.7 to the last release that supported them.