### PR TITLE
Avoid overlapping versions being created during restore

### DIFF
--- a/versions/models.py
+++ b/versions/models.py
@@ -1479,6 +1479,7 @@ class Versionable(models.Model):
             latest = cls.objects.current_version(self, check_db=True)
             if latest and latest != self:
                 latest.delete()
+                restored.version_start_date = latest.version_end_date
 
             self.save()
             restored.save()

--- a/versions_tests/tests/test_models.py
+++ b/versions_tests/tests/test_models.py
@@ -2410,6 +2410,9 @@ class VersionRestoreTest(TestCase):
         self.assertSetEqual(set(previous.awards.all()), set(self.awards.values()))
         self.assertEqual(self.forty_niners, previous.team)
 
+        # There should be no overlap of version periods.
+        self.assertEquals(previous.version_end_date, restored.version_start_date)
+
     def test_restore_with_required_foreignkey(self):
         team = Team.objects.create(name="Flying Pigs")
         mascot_v1 = Mascot.objects.create(name="Curly", team=team)


### PR DESCRIPTION
Overlapping versions were being created when restore() was
called on an old version of an object when a current version
(version_end_date == null) existed.

The terminated current version had a version_end_date that was
greater than version_start_date of the newly restored version.