### PR TITLE
Fixed issue that made Restore and Save Without Cloning buttons disapp…

### DIFF
--- a/versions/admin.py
+++ b/versions/admin.py
@@ -320,7 +320,7 @@ class VersionedAdmin(admin.ModelAdmin):
     identity_shortener.boolean = False
     identity_shortener.short_description = "Short Identity"
 
-    class Media():
+    class Media:
         # This supports dynamically adding 'Save without cloning' button:
         # http://bit.ly/1T2fGOP
         js = ('js/admin_addon.js',)


### PR DESCRIPTION
…ear in Python 3.

Recently switched from Python 2 to Python 3 and realized that the 'Restore' and 'Save without cloning' buttons were no longer in Django admin. It had to do with using parens after `Media`, so I removed the parens and it fixed the problem. 