### PR TITLE
fixes test errors when using with custom user model

### DIFF
--- a/versions_tests/tests/test_admin.py
+++ b/versions_tests/tests/test_admin.py
@@ -1,5 +1,5 @@
 from django.contrib.admin.sites import AdminSite
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 try:
     from django.urls import reverse
@@ -9,6 +9,8 @@ except ImportError:
 
 from versions.admin import VersionedAdmin
 from ..models import City
+
+User = get_user_model()
 
 
 class VersionedAdminTest(TestCase):


### PR DESCRIPTION
When using version_tests in a project with a custom user model, tests failed.
It's common best practice to use get_user_model() to fix this problem.
Keep up the great work!